### PR TITLE
move rikai.vision to rikai.types.vision

### DIFF
--- a/python/rikai/spark/functions.py
+++ b/python/rikai/spark/functions.py
@@ -21,8 +21,7 @@ from pyspark.sql.types import FloatType, StringType
 from rikai.io import copy as _copy
 from rikai.logging import logger
 from rikai.spark.types import ImageType, LabelType
-from rikai.vision import Image, Label
-from rikai.types import Box2d
+from rikai.types import Box2d, Image, Label
 
 __all__ = ["label", "area", "copy", "image_copy"]
 

--- a/python/rikai/spark/types/__init__.py
+++ b/python/rikai/spark/types/__init__.py
@@ -21,10 +21,8 @@ from pyspark.sql import Row
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
-    DataType,
     IntegerType,
     ShortType,
-    StringType,
     StructField,
     StructType,
     UserDefinedType,
@@ -34,7 +32,13 @@ from pyspark.sql.types import (
 import rikai
 from rikai.convert import PortableDataType
 from rikai.logging import logger
-from rikai.types.geometry import PointType, Box3dType, Box2dType
+from rikai.spark.types.geometry import Box2dType, Box3dType, PointType
+from rikai.spark.types.vision import (
+    ImageType,
+    LabelType,
+    VideoStreamType,
+    YouTubeVideoType,
+)
 
 __all__ = [
     "ImageType",
@@ -46,41 +50,6 @@ __all__ = [
     "VideoStreamType",
     "YouTubeVideoType",
 ]
-
-
-class ImageType(UserDefinedType):
-    """ImageType defines the Spark UserDefineType for Image type"""
-
-    def __init__(self):
-        super().__init__()
-        self.codec = "png"
-
-    def __repr__(self) -> str:
-        return f"ImageType(codec={self.codec})"
-
-    @classmethod
-    def sqlType(cls) -> StructType:
-        return StructType(fields=[StructField("uri", StringType(), nullable=False)])
-
-    @classmethod
-    def module(cls) -> str:
-        return "rikai.spark.types"
-
-    @classmethod
-    def scalaUDT(cls) -> str:
-        return "org.apache.spark.sql.rikai.ImageType"
-
-    def serialize(self, obj: "Image"):
-        """Serialize an Image to a Spark Row?"""
-        return (obj.uri,)
-
-    def deserialize(self, datum) -> "Image":
-        from rikai.vision import Image  # pylint: disable=import-outside-toplevel
-
-        return Image(datum[0])
-
-    def simpleString(self) -> str:
-        return "ImageType"
 
 
 class NDArrayType(UserDefinedType):
@@ -141,108 +110,3 @@ class NDArrayType(UserDefinedType):
 
     def simpleString(self) -> str:
         return "ndarray"
-
-
-class LabelType(UserDefinedType):
-    """Label type"""
-
-    def __repr__(self) -> str:
-        return "LabelType"
-
-    @classmethod
-    def sqlType(cls) -> DataType:
-        return StringType()
-
-    @classmethod
-    def module(cls) -> str:
-        return "rikai.spark.types"
-
-    @classmethod
-    def scalaUDT(cls) -> str:
-        return "org.apache.spark.sql.rikai.LabelType"
-
-    def serialize(self, obj: "Label"):
-        """Serialize a label into Spark String"""
-        return obj.label
-
-    def deserialize(self, datum: Row) -> "Label":
-        from rikai.vision import Label
-
-        return Label(datum)
-
-    def simpleString(self) -> str:
-        return "label"
-
-
-class VideoStreamType(UserDefinedType):
-    """VideoStreamType defines the Spark UserDefineType for
-    a given video stream
-    """
-
-    def __init__(self):
-        super().__init__()
-        self.codec = "mp4"  # TODO allow generic code
-
-    def __repr__(self) -> str:
-        return f"VideoType(codec={self.codec})"
-
-    @classmethod
-    def sqlType(cls) -> StructType:
-        return StructType(fields=[StructField("uri", StringType(), nullable=False)])
-
-    @classmethod
-    def module(cls) -> str:
-        return "rikai.spark.types"
-
-    @classmethod
-    def scalaUDT(cls) -> str:
-        return "org.apache.spark.sql.rikai.VideoStreamType"
-
-    def serialize(self, obj: "VideoStream"):
-        """Serialize a VideoStream to a Spark Row"""
-        return (obj.uri,)
-
-    def deserialize(self, datum) -> "VideoStream":
-        from rikai.vision import VideoStream  # pylint: disable=import-outside-toplevel
-
-        return VideoStream(datum[0])
-
-    def simpleString(self) -> str:
-        return "VideoStreamType"
-
-
-class YouTubeVideoType(UserDefinedType):
-    """YouTubeVideoType defines the Spark UserDefineType for
-    a piece of YouTube video content (i.e., corresponds to a given
-    youtube id but can have multiple streams)
-    """
-
-    def __init__(self):
-        super().__init__()
-
-    def __repr__(self) -> str:
-        return "YouTubeVideoType"
-
-    @classmethod
-    def sqlType(cls) -> StructType:
-        return StructType(fields=[StructField("vid", StringType(), nullable=False)])
-
-    @classmethod
-    def module(cls) -> str:
-        return "rikai.spark.types"
-
-    @classmethod
-    def scalaUDT(cls) -> str:
-        return "org.apache.spark.sql.rikai.YouTubeVideoType"
-
-    def serialize(self, obj: "YouTubeVideo"):
-        """Serialize an Image to a Spark Row?"""
-        return (obj.vid,)
-
-    def deserialize(self, datum) -> "YouTubeVideo":
-        from rikai.vision import YouTubeVideo  # pylint: disable=import-outside-toplevel
-
-        return YouTubeVideo(datum[0])
-
-    def simpleString(self) -> str:
-        return "YouTubeVideoType"

--- a/python/rikai/spark/types/vision.py
+++ b/python/rikai/spark/types/vision.py
@@ -1,0 +1,169 @@
+#  Copyright 2021 Rikai Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from pyspark.sql import Row
+from pyspark.sql.types import (
+    DataType,
+    StringType,
+    StructField,
+    StructType,
+    UserDefinedType,
+)
+
+__all__ = ["ImageType"]
+
+
+class ImageType(UserDefinedType):
+    """ImageType defines the Spark UserDefineType for Image type"""
+
+    def __init__(self):
+        super().__init__()
+        self.codec = "png"
+
+    def __repr__(self) -> str:
+        return f"ImageType(codec={self.codec})"
+
+    @classmethod
+    def sqlType(cls) -> StructType:
+        return StructType(fields=[StructField("uri", StringType(), nullable=False)])
+
+    @classmethod
+    def module(cls) -> str:
+        return "rikai.spark.types.vision"
+
+    @classmethod
+    def scalaUDT(cls) -> str:
+        return "org.apache.spark.sql.rikai.ImageType"
+
+    def serialize(self, obj: "Image"):
+        """Serialize an Image to a Spark Row?"""
+        return (obj.uri,)
+
+    def deserialize(self, datum) -> "Image":
+        from rikai.types.vision import Image  # pylint: disable=import-outside-toplevel
+
+        return Image(datum[0])
+
+    def simpleString(self) -> str:
+        return "ImageType"
+
+
+class LabelType(UserDefinedType):
+    """Label type"""
+
+    def __repr__(self) -> str:
+        return "LabelType"
+
+    @classmethod
+    def sqlType(cls) -> DataType:
+        return StringType()
+
+    @classmethod
+    def module(cls) -> str:
+        return "rikai.spark.types.vision"
+
+    @classmethod
+    def scalaUDT(cls) -> str:
+        return "org.apache.spark.sql.rikai.LabelType"
+
+    def serialize(self, obj: "Label"):
+        """Serialize a label into Spark String"""
+        return obj.label
+
+    def deserialize(self, datum: Row) -> "Label":
+        from rikai.types.vision import Label
+
+        return Label(datum)
+
+    def simpleString(self) -> str:
+        return "label"
+
+
+class VideoStreamType(UserDefinedType):
+    """VideoStreamType defines the Spark UserDefineType for
+    a given video stream
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.codec = "mp4"  # TODO allow generic code
+
+    def __repr__(self) -> str:
+        return f"VideoType(codec={self.codec})"
+
+    @classmethod
+    def sqlType(cls) -> StructType:
+        return StructType(fields=[StructField("uri", StringType(), nullable=False)])
+
+    @classmethod
+    def module(cls) -> str:
+        return "rikai.spark.types.vision"
+
+    @classmethod
+    def scalaUDT(cls) -> str:
+        return "org.apache.spark.sql.rikai.VideoStreamType"
+
+    def serialize(self, obj: "VideoStream"):
+        """Serialize a VideoStream to a Spark Row"""
+        return (obj.uri,)
+
+    def deserialize(self, datum) -> "VideoStream":
+        from rikai.types.vision import (
+            VideoStream,
+        )  # pylint: disable=import-outside-toplevel
+
+        return VideoStream(datum[0])
+
+    def simpleString(self) -> str:
+        return "VideoStreamType"
+
+
+class YouTubeVideoType(UserDefinedType):
+    """YouTubeVideoType defines the Spark UserDefineType for
+    a piece of YouTube video content (i.e., corresponds to a given
+    youtube id but can have multiple streams)
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def __repr__(self) -> str:
+        return "YouTubeVideoType"
+
+    @classmethod
+    def sqlType(cls) -> StructType:
+        return StructType(fields=[StructField("vid", StringType(), nullable=False)])
+
+    @classmethod
+    def module(cls) -> str:
+        return "rikai.spark.types.vision"
+
+    @classmethod
+    def scalaUDT(cls) -> str:
+        return "org.apache.spark.sql.rikai.YouTubeVideoType"
+
+    def serialize(self, obj: "YouTubeVideo"):
+        """Serialize an Image to a Spark Row?"""
+        return (obj.vid,)
+
+    def deserialize(self, datum) -> "YouTubeVideo":
+        from rikai.types.vision import (
+            YouTubeVideo,
+        )  # pylint: disable=import-outside-toplevel
+
+        return YouTubeVideo(datum[0])
+
+    def simpleString(self) -> str:
+        return "YouTubeVideoType"

--- a/python/rikai/spark/types/vision.py
+++ b/python/rikai/spark/types/vision.py
@@ -22,7 +22,7 @@ from pyspark.sql.types import (
     UserDefinedType,
 )
 
-__all__ = ["ImageType"]
+__all__ = ["ImageType", "LabelType", "VideoStreamType", "YouTubeVideoType"]
 
 
 class ImageType(UserDefinedType):

--- a/python/rikai/types/__init__.py
+++ b/python/rikai/types/__init__.py
@@ -16,3 +16,4 @@
 """
 
 from rikai.types.geometry import Point, Box3d, Box2d
+from rikai.types.vision import VideoStream, YouTubeVideo, Image, Label

--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -1,4 +1,3 @@
-#  Copyright 2020 Rikai Authors
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,21 +13,20 @@
 
 """Vision Related Types
 """
+
+import os
+import pathlib
+
+# 3rd party
+import numpy as np
 from PIL import Image as PILImage
 
-import numpy as np
+# Rikai
 from rikai.mixin import Asset, ToNumpy
-from rikai.spark.types import ImageType, LabelType
+from rikai.spark.types import ImageType, LabelType, VideoStreamType, YouTubeVideoType
 from rikai.types.geometry import Box2d
 
-from rikai.spark.types import (
-    ImageType,
-    LabelType,
-    YouTubeVideoType,
-    VideoStreamType,
-)
-
-__all__ = ["Image", "Box2d", "Label", "YouTubeVideo", "VideoSegment", "VideoStream"]
+__all__ = ["Image", "Label", "YouTubeVideo", "VideoStream"]
 
 
 class Image(ToNumpy, Asset):

--- a/python/tests/analyze/test_vision.py
+++ b/python/tests/analyze/test_vision.py
@@ -19,9 +19,9 @@
 from pyspark.sql import Row
 
 # Rikai
-from rikai.testing import SparkTestCase
-from rikai.vision import Label
 from rikai.analyze.vision import LabelDistributionRule
+from rikai.testing import SparkTestCase
+from rikai.types.vision import Label
 
 
 class VisionRulesTest(SparkTestCase):

--- a/python/tests/parquet/test_parquet_udt.py
+++ b/python/tests/parquet/test_parquet_udt.py
@@ -33,8 +33,7 @@ from pyspark.sql.types import (
 from rikai.parquet import Dataset
 from rikai.spark.types import NDArrayType
 from rikai.testing import SparkTestCase
-from rikai.vision import Image
-from rikai.types import Box2d
+from rikai.types import Box2d, Image
 
 
 class TestParquetUdt(SparkTestCase):

--- a/python/tests/spark/test_functions.py
+++ b/python/tests/spark/test_functions.py
@@ -17,12 +17,10 @@
 import os
 
 from pyspark.sql.functions import col, lit
-import numpy as np
 
 from rikai.spark.functions import area, image_copy
 from rikai.testing.spark import SparkTestCase
-from rikai.vision import Image
-from rikai.types import Box2d
+from rikai.types import Box2d, Image
 
 
 class SparkFunctionsTest(SparkTestCase):

--- a/python/tests/torch/test_data.py
+++ b/python/tests/torch/test_data.py
@@ -25,7 +25,7 @@ from pyspark.sql import Row
 
 # Rikai
 from rikai.numpy import wrap
-from rikai.vision import Image
+from rikai.types.vision import Image
 from rikai.types.geometry import Box2d
 from rikai.testing.spark import SparkTestCase
 from rikai.torch import DataLoader

--- a/src/main/scala/org/apache/spark/sql/rikai/Image.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/Image.scala
@@ -32,7 +32,7 @@ private[spark] class ImageType extends UserDefinedType[Image] {
       )
     )
 
-  override def pyUDT: String = "rikai.spark.types.ImageType"
+  override def pyUDT: String = "rikai.spark.types.vision.ImageType"
 
   override def serialize(obj: Image): Any = {
     val row = new GenericInternalRow(1);

--- a/src/main/scala/org/apache/spark/sql/rikai/Label.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/Label.scala
@@ -26,7 +26,7 @@ private[spark] class LabelType extends UserDefinedType[Label] {
 
   override def sqlType: DataType = StringType
 
-  override def pyUDT: String = "rikai.spark.types.LabelType"
+  override def pyUDT: String = "rikai.spark.types.vision.LabelType"
 
   override def serialize(obj: Label): Any = {
     UTF8String.fromString(obj.label)

--- a/src/main/scala/org/apache/spark/sql/rikai/Video.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/Video.scala
@@ -36,10 +36,10 @@ class VideoStreamType extends UserDefinedType[VideoStream] {
     StructType(
       Seq(
         StructField("uri", StringType, false)
-        )
       )
+    )
 
-  override def pyUDT: String = "rikai.spark.types.VideoStreamType"
+  override def pyUDT: String = "rikai.spark.types.vision.VideoStreamType"
 
   override def serialize(obj: VideoStream): Any = {
     val row = new GenericInternalRow(1);
@@ -77,10 +77,10 @@ class YouTubeVideoType extends UserDefinedType[YouTubeVideo] {
     StructType(
       Seq(
         StructField("vid", StringType, false)
-        )
       )
+    )
 
-  override def pyUDT: String = "rikai.spark.types.YouTubeVideoType"
+  override def pyUDT: String = "rikai.spark.types.vision.YouTubeVideoType"
 
   override def serialize(obj: YouTubeVideo): Any = {
     val row = new GenericInternalRow(1);


### PR DESCRIPTION
Reconstruct the namespace to move all semantic types into `rikai.types` module