### PR TITLE
Fix parquet dataset column selection

### DIFF
--- a/python/rikai/testing/spark.py
+++ b/python/rikai/testing/spark.py
@@ -28,10 +28,11 @@ __all__ = ["SparkTestCase"]
 class SparkTestCase(unittest.TestCase):
     """Basic class for Running Spark Tests
 
-    Tests can access an initialized spark session via `self.spark`
+    Tests can access an initialized :py:class:`SparkSession`
+    via :py:attribute:`self.spark`
     """
 
-    spark = None
+    spark: SparkSession = None
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -63,4 +64,4 @@ class SparkTestCase(unittest.TestCase):
         self.test_dir = self._tmpdir.name
 
     def tearDown(self) -> None:
-        self._tmpdir.cleanup
+        self._tmpdir.cleanup()

--- a/python/tests/parquet/test_dataset.py
+++ b/python/tests/parquet/test_dataset.py
@@ -29,10 +29,7 @@ class DatasetTest(SparkTestCase):
         df.write.format("rikai").save(self.test_dir)
 
         dataset = Dataset(self.test_dir, columns=["id", "col1"])
-        actual = []
-        for example in dataset:
-            actual.append(example)
-        actual = sorted(actual, key=lambda x: x["id"])
+        actual = sorted(list(dataset), key=lambda x: x["id"])
 
         self.assertCountEqual(
             [{"id": 1, "col1": "value"}, {"id": 2, "col1": "more"}], actual

--- a/python/tests/parquet/test_dataset.py
+++ b/python/tests/parquet/test_dataset.py
@@ -12,12 +12,28 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# Third Party
+from pyspark.sql import Row
+
 # Rikai
-from rikai.testing import SparkTestCase
 from rikai.parquet import Dataset
+from rikai.testing import SparkTestCase
 
 
 class DatasetTest(SparkTestCase):
     def test_select_columns(self):
-        self.assertEqual(True, False)
+        """Test reading rikai dataset with selected columns."""
+        df = self.spark.createDataFrame(
+            [Row(id=1, col1="value", col2=123), Row(id=2, col1="more", col2=456)]
+        )
+        df.write.format("rikai").save(self.test_dir)
 
+        dataset = Dataset(self.test_dir, columns=["id", "col1"])
+        actual = []
+        for example in dataset:
+            actual.append(example)
+        actual = sorted(actual, key=lambda x: x["id"])
+
+        self.assertCountEqual(
+            [{"id": 1, "col1": "value"}, {"id": 2, "col1": "more"}], actual
+        )

--- a/python/tests/parquet/test_dataset.py
+++ b/python/tests/parquet/test_dataset.py
@@ -1,0 +1,23 @@
+#  Copyright 2021 Rikai Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Rikai
+from rikai.testing import SparkTestCase
+from rikai.parquet import Dataset
+
+
+class DatasetTest(SparkTestCase):
+    def test_select_columns(self):
+        self.assertEqual(True, False)
+


### PR DESCRIPTION
Parquet dataset failed to select specific columns, as reported in #29.

The conversion of data types does not take into account of selected columns. 