### PR TITLE
Remove parameterized package from test

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -7,7 +7,7 @@ with open(pathlib.Path("rikai") / "__version__.py", "r") as fh:
     exec(fh.read(), about)
 
 # extras
-test = ["pytest", "parameterized"]
+test = ["pytest"]
 torch = ["torch>=1.5.0", "torchvision"]
 jupyter = ["matplotlib", "jupyterlab"]
 aws = ["boto"]


### PR DESCRIPTION
We can use `pytest.mark.parameterize` now