### PR TITLE
Provide torch Dataset using its IterableDataset interface

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         sudo apt-get -y -qq install libsnappy-dev
         python -m pip install -q wheel pylint black flake8
-        python -m pip install -e .[test,youtube]
+        python -m pip install -e .[all]
     - name: Python black and flake8
       if: ${{ matrix.python-version == 3.8 }}
       run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ python/rikai/jars/
 
 .idea/
 .vscode/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,6 @@
 all:
 
 lint:
-	black --check python/rikai python/tests
+	black -l 79 --check python/rikai python/tests
 	pycodestyle python/rikai python/tests
 .PHONY: lint

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,11 @@ author = "Rikai Authors"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.napoleon", "sphinx.ext.autodoc"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+]
 
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True
@@ -69,3 +73,9 @@ html_theme = "alabaster"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+intersphinx_mapping = {
+    "numpy": ("http://docs.scipy.org/doc/numpy/", None),
+    "python": ("https://docs.python.org/", None),
+    "PyTorch": ("http://pytorch.org/docs/master/", None),
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.black]
 line-length = 79
 target-version = ['py38']
+max-line-length = 79
 
 [tool.isort]
 known_third_party = ["torch", "pyspark", "PIL", "pytest"]

--- a/python/rikai/mixin.py
+++ b/python/rikai/mixin.py
@@ -16,7 +16,7 @@
 """
 from __future__ import annotations
 
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import BinaryIO, Union
 from urllib.parse import urlparse

--- a/python/rikai/numpy.py
+++ b/python/rikai/numpy.py
@@ -36,15 +36,21 @@ import numpy as np
 
 # Rikai
 from rikai.spark.types import NDArrayType
+from rikai.mixin import ToNumpy
 
 
 __all__ = ["wrap", "array", "empty"]
 
 
-class ndarray(np.ndarray):  # pylint: disable=invalid-name
+class ndarray(np.ndarray, ToNumpy):  # pylint: disable=invalid-name
     """This class extends numpy ndarray to be serialized in Spark."""
 
     __UDT__ = NDArrayType()
+
+    def to_numpy(self) -> np.ndarray:
+        """Convert to a pure numpy array for compatibility"""
+        # TODO: optimize it for zero-copy
+        return np.copy(self)
 
 
 def wrap(data: np.ndarray) -> np.ndarray:

--- a/python/rikai/parquet/dataset.py
+++ b/python/rikai/parquet/dataset.py
@@ -187,6 +187,13 @@ class Dataset:
         shuffler = RandomShuffler(
             self.shuffler_capacity if self.shuffle else 1, self.seed
         )
+        logger.info(
+            "Start to iterate : rank=%s, world=%s, files=%s",
+            self.rank,
+            self.world_size,
+            self.files,
+        )
+
         group_count = 0
         for filepath in self.files:
             fs, path = FileSystem.from_uri(filepath)
@@ -204,9 +211,11 @@ class Dataset:
                     #   The drawback would be if the world size is much larger
                     #   than the average number of row groups. As a result,
                     #   many of the file open operations would be wasted.
-                    group_count += 1
+                    print("Lets try group count: ", group_count)
                     if group_count % self.world_size != self.rank:
+                        group_count += 1
                         continue
+                    group_count += 1
                     row_group = parquet.read_row_group(
                         group_idx, columns=self.columns
                     )

--- a/python/rikai/parquet/dataset.py
+++ b/python/rikai/parquet/dataset.py
@@ -215,26 +215,16 @@ class Dataset:
                     ) in row_group.to_batches():  # type: pyarrow.RecordBatch
                         # TODO: read batches not using pandas
                         # print("THIS BATCH: rows=", batch.num_rows)
-                        for idx, row in batch.to_pandas().iterrows():
-                            print(f"Yield row: {idx}")
-                            yield self._convert(
-                                row.to_dict(), self.spark_row_metadata
-                            )
-                            yield_count += 1
-                        #     shuffler.append(row)
-                        #     # Maintain the shuffler buffer around its capacity.
+                        for _, row in batch.to_pandas().iterrows():
+                            shuffler.append(row)
+                            # Maintain the shuffler buffer around its capacity.
 
-                        #     while shuffler.full():
-                        #         yield self._convert(
-                        #             shuffler.pop().to_dict(),
-                        #             self.spark_row_metadata,
-                        #         )
-        # while shuffler:
-        #     yield self._convert(
-        #         shuffler.pop().to_dict(), self.spark_row_metadata
-        #     )
-        print(
-            f"XXX Finish One Dataset rank={self.rank} total={self.world_size}"
-        )
-        if not yield_count:
-            return iter([])
+                            while shuffler.full():
+                                yield self._convert(
+                                    shuffler.pop().to_dict(),
+                                    self.spark_row_metadata,
+                                )
+        while shuffler:
+            yield self._convert(
+                shuffler.pop().to_dict(), self.spark_row_metadata
+            )

--- a/python/rikai/parquet/dataset.py
+++ b/python/rikai/parquet/dataset.py
@@ -187,7 +187,7 @@ class Dataset:
         shuffler = RandomShuffler(
             self.shuffler_capacity if self.shuffle else 1, self.seed
         )
-        group_count = 0
+        group_count = -1
         for filepath in self.files:
             fs, path = FileSystem.from_uri(filepath)
             with fs.open_input_file(path) as fobj:
@@ -205,7 +205,7 @@ class Dataset:
                     #   than the average number of row groups. As a result,
                     #   many of the file open operations would be wasted.
                     group_count += 1
-                    if (group_count - 1) % self.world_size != self.rank:
+                    if group_count % self.world_size != self.rank:
                         continue
                     row_group = parquet.read_row_group(
                         group_idx, columns=self.columns

--- a/python/rikai/parquet/dataset.py
+++ b/python/rikai/parquet/dataset.py
@@ -214,7 +214,6 @@ class Dataset:
                         batch
                     ) in row_group.to_batches():  # type: pyarrow.RecordBatch
                         # TODO: read batches not using pandas
-                        # print("THIS BATCH: rows=", batch.num_rows)
                         for _, row in batch.to_pandas().iterrows():
                             shuffler.append(row)
                             # Maintain the shuffler buffer around its capacity.

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -35,7 +35,7 @@ class Dataset(IterableDataset):
     """Rikai Pytorch Dataset.
 
     A :py:class:`torch.utils.data.IterableDataset` that reads
-    Rikai's parquet format. This class works with `multi-process data loading_`
+    Rikai's parquet format. This class works with `multi-process data loading`_
     using :py:class:`torch.utils.data.DataLoader`.
 
     Parameters
@@ -45,8 +45,27 @@ class Dataset(IterableDataset):
     columns : list of str, optional
         An optional list of column to load from parquet files.
     transform : callable, optional
-        A function/transform that transforms one example
-    """
+        A function/transform that transforms one example.
+
+
+    Note
+    ----
+
+    Up to ``pytorch==1.7``, :py:class:`~torch.utils.data.IterableDataset`
+    does not work with :py:class:`torch.utils.data.Sampler` with
+    :py:class:`torch.utils.data.DataLoader`.
+
+    Example
+    -------
+
+    >>> from rikai.torch.data import Dataset
+    >>> from torch.utils.data import DataLoader
+    >>>
+    >>> dataset = Dataset("dataset", columns=["image", "label"])
+    >>> loader = DataLoader(dataset, num_workers=8)
+
+    .. _multi-process data loading: https://pytorch.org/docs/master/data.html#single-and-multi-process-data-loading
+    """  # noqa: E501
 
     def __init__(
         self,

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -35,8 +35,8 @@ class Dataset(IterableDataset):
     """Rikai Pytorch Dataset.
 
     A :py:class:`torch.utils.data.IterableDataset` that reads
-    Rikai's parquet format. This class works with `multi-process data loading`_
-    using :py:class:`torch.utils.data.DataLoader`.
+    Rikai data format. This :py:class:`Dataset` works with
+    `multi-process data loading`_ using :py:class:`torch.utils.data.DataLoader`.
 
     Parameters
     ----------
@@ -44,9 +44,6 @@ class Dataset(IterableDataset):
         URI to the dataset
     columns : list of str, optional
         An optional list of column to load from parquet files.
-    transform : callable, optional
-        A function/transform that transforms one example.
-
 
     Note
     ----
@@ -55,13 +52,16 @@ class Dataset(IterableDataset):
     does not work with :py:class:`torch.utils.data.Sampler` with
     :py:class:`torch.utils.data.DataLoader`.
 
+    Use :py:class:`torch.utils.data.BufferedShuffleDataset` with the Rikai dataset.
+
     Example
     -------
 
     >>> from rikai.torch.data import Dataset
-    >>> from torch.utils.data import DataLoader
+    >>> from torch.utils.data import DataLoader, BufferedShuffleDataset
     >>>
     >>> dataset = Dataset("dataset", columns=["image", "label"])
+    >>> # dataset = BufferedShuffleDataset(dataset)
     >>> loader = DataLoader(dataset, num_workers=8)
 
     .. _multi-process data loading: https://pytorch.org/docs/master/data.html#single-and-multi-process-data-loading
@@ -71,7 +71,6 @@ class Dataset(IterableDataset):
         self,
         uri: str,
         columns: List[str] = None,
-        transform: Optional[Callable] = None,
     ):
         super().__init__()
         self.uri = uri
@@ -87,9 +86,9 @@ class Dataset(IterableDataset):
             rank = worker_info.id
             world_size = worker_info.num_workers
 
-        dataset = pgDataset(
+        for row in pgDataset(
             self.uri,
-            columns=self.columns,
+            # columns=self.columns,
             world_size=world_size,
             rank=rank,
         )

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -37,15 +37,21 @@ class Dataset(IterableDataset):
     """Rikai Pytorch Dataset.
 
     A :py:class:`torch.utils.data.IterableDataset` that reads
-    Rikai's parquet format.
-
+    Rikai's parquet format. This class works with `multi-process data loading_`
+    using :py:class:`torch.utils.data.DataLoader`.
 
     """
 
-    def __init__(self, uri: str, columns: List[str] = None):
+    def __init__(
+        self,
+        uri: str,
+        columns: List[str] = None,
+        transform: Optional[Callable] = None,
+    ):
         super().__init__()
         self.uri = uri
         self.columns = columns
+        self.transform = transform if transform else lambda x: x
 
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
@@ -61,7 +67,7 @@ class Dataset(IterableDataset):
                 rank=rank,
             )
         for row in dataset:
-            yield convert_tensor(row)
+            yield self.transform(convert_tensor(row))
 
 
 class DataLoader:

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -27,7 +27,7 @@ from torch.utils.data import IterableDataset
 
 # Rikai
 from rikai.mixin import ToNumpy
-from rikai.parquet.dataset import Dataset as pgDataset
+from rikai.parquet.dataset import Dataset as pqDataset
 
 __all__ = ["DataLoader", "Dataset"]
 
@@ -90,7 +90,7 @@ class Dataset(IterableDataset):
             rank = worker_info.id
             world_size = worker_info.num_workers
 
-        for row in pgDataset(
+        for row in pqDataset(
             self.uri,
             columns=self.columns,
             world_size=world_size,
@@ -167,7 +167,7 @@ class DataLoader:
         world_size: int = 1,
         rank: int = 0,
     ):  # pylint: disable=too-many-arguments
-        self.dataset = pgDataset(
+        self.dataset = pqDataset(
             dataset,
             columns=columns,
             shuffle=shuffle,

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -75,7 +75,6 @@ class Dataset(IterableDataset):
         super().__init__()
         self.uri = uri
         self.columns = columns
-        self.transform = transform
 
     def __iter__(self):
         rank = 0
@@ -91,13 +90,8 @@ class Dataset(IterableDataset):
             columns=self.columns,
             world_size=world_size,
             rank=rank,
-        )
-        for row in dataset:
-            tensor = convert_tensor(row)
-            if self.transform:
-                tensor = self.transform(tensor)
-            print("Converted tensor: ", tensor)
-            yield tensor
+        ):
+            yield convert_tensor(row)
 
 
 class DataLoader:

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -26,8 +26,8 @@ import torch
 from torch.utils.data import IterableDataset
 
 # Rikai
+import rikai.parquet
 from rikai.mixin import ToNumpy
-from rikai.parquet.dataset import Dataset as pqDataset
 
 __all__ = ["DataLoader", "Dataset"]
 
@@ -90,7 +90,7 @@ class Dataset(IterableDataset):
             rank = worker_info.id
             world_size = worker_info.num_workers
 
-        for row in pqDataset(
+        for row in rikai.parquet.Dataset(
             self.uri,
             columns=self.columns,
             world_size=world_size,
@@ -167,7 +167,7 @@ class DataLoader:
         world_size: int = 1,
         rank: int = 0,
     ):  # pylint: disable=too-many-arguments
-        self.dataset = pqDataset(
+        self.dataset = rikai.parquet.Dataset(
             dataset,
             columns=columns,
             shuffle=shuffle,

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -60,7 +60,8 @@ class Dataset(IterableDataset):
                 world_size=world_size,
                 rank=rank,
             )
-        return iter(dataset)
+        for row in dataset:
+            yield convert_tensor(row)
 
 
 class DataLoader:

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -88,7 +88,7 @@ class Dataset(IterableDataset):
 
         for row in pgDataset(
             self.uri,
-            # columns=self.columns,
+            columns=self.columns,
             world_size=world_size,
             rank=rank,
         )

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -16,8 +16,9 @@
 
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from queue import Empty, Queue
-from typing import Callable, Dict, Generator, List, Optional
+from typing import Callable, Dict, Generator, List, Optional, Union
 
 # Third Party
 import numpy as np
@@ -70,11 +71,11 @@ class Dataset(IterableDataset):
 
     def __init__(
         self,
-        uri: str,
+        uri: Union[str, Path],
         columns: List[str] = None,
     ):
         super().__init__()
-        self.uri = uri
+        self.uri = str(uri)
         self.columns = columns
 
     def __repr__(self) -> str:

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -52,13 +52,14 @@ class Dataset(IterableDataset):
     does not work with :py:class:`torch.utils.data.Sampler` with
     :py:class:`torch.utils.data.DataLoader`.
 
-    Use :py:class:`torch.utils.data.BufferedShuffleDataset` with the Rikai dataset.
+    Use :py:class:`torch.utils.data.BufferedShuffleDataset` (torch>=1.8)
+    with the Rikai dataset for randomness.
 
     Example
     -------
 
     >>> from rikai.torch.data import Dataset
-    >>> from torch.utils.data import DataLoader, BufferedShuffleDataset
+    >>> from torch.utils.data import DataLoader
     >>>
     >>> dataset = Dataset("dataset", columns=["image", "label"])
     >>> # dataset = BufferedShuffleDataset(dataset)
@@ -75,6 +76,9 @@ class Dataset(IterableDataset):
         super().__init__()
         self.uri = uri
         self.columns = columns
+
+    def __repr__(self) -> str:
+        return f"Dataset(torch, {self.uri}, columns={self.columns})"
 
     def __iter__(self):
         rank = 0

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -15,7 +15,7 @@
 
 # Third Party
 import pytest
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader  # Prevent DataLoader hangs
 from pyspark.sql import SparkSession
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -15,6 +15,7 @@
 
 # Third Party
 import pytest
+from torch.utils.data import DataLoader
 from pyspark.sql import SparkSession
 
 

--- a/python/tests/parquet/test_shuffler.py
+++ b/python/tests/parquet/test_shuffler.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 
+from random import shuffle
 from rikai.parquet.shuffler import RandomShuffler
 
 
@@ -52,3 +53,14 @@ def test_fifo():
     shuffler = RandomShuffler(capacity=1)
     returned = shuffle_numbers(shuffler, range(100))
     assert len(returned) == 100
+
+
+def test_fifo_with_single_item():
+    shuffler = RandomShuffler(capacity=1)
+    shuffler.append(1)
+    assert shuffler
+    assert shuffler.full()
+    assert len(shuffler) == 1
+    assert shuffler.pop() == 1
+
+    assert not shuffler.full()

--- a/python/tests/parquet/test_shuffler.py
+++ b/python/tests/parquet/test_shuffler.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 
-from random import shuffle
 from rikai.parquet.shuffler import RandomShuffler
 
 

--- a/python/tests/torch/conftest.py
+++ b/python/tests/torch/conftest.py
@@ -1,0 +1,21 @@
+#  Copyright 2021 Rikai Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+import torch
+
+
+@pytest.fixture(autouse=True)
+def torch_setup():
+    torch.multiprocessing.set_sharing_strategy("file_system")

--- a/python/tests/torch/test_data.py
+++ b/python/tests/torch/test_data.py
@@ -147,7 +147,6 @@ def test_torch_dataset(spark, tmp_path, num_workers):
     df = spark.createDataFrame(data)
     df.write.mode("overwrite").format("rikai").save(str(dataset_dir))
     dataset = Dataset(str(dataset_dir))
-    print(dataset)
     loader = torchDataLoader(
         dataset,
         num_workers=num_workers,

--- a/python/tests/torch/test_data.py
+++ b/python/tests/torch/test_data.py
@@ -28,6 +28,8 @@ from rikai.numpy import wrap
 from rikai.torch import DataLoader, Dataset
 from rikai.types import Box2d, Image
 
+torch.multiprocessing.set_sharing_strategy("file_system")
+
 
 def test_load_dataset(spark: SparkSession, tmp_path: Path):
     dataset_dir = tmp_path / "features"

--- a/python/tests/torch/test_data.py
+++ b/python/tests/torch/test_data.py
@@ -146,7 +146,7 @@ def test_torch_dataset(spark, tmp_path, num_workers):
 
     df = spark.createDataFrame(data)
     df.write.mode("overwrite").format("rikai").save(str(dataset_dir))
-    dataset = Dataset(str(dataset_dir))
+    dataset = Dataset(dataset_dir)
     loader = torchDataLoader(
         dataset,
         num_workers=num_workers,

--- a/python/tests/torch/test_data.py
+++ b/python/tests/torch/test_data.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 # Standard Library
-import os
 from pathlib import Path
 
 # Third Party

--- a/python/tests/torch/test_data.py
+++ b/python/tests/torch/test_data.py
@@ -126,7 +126,7 @@ def test_torch_dataset(spark, tmp_path, num_workers):
     for i in range(total):
         image_data = np.random.randint(0, 128, size=(128, 128), dtype=np.uint8)
         image_uri = asset_dir / f"{i}.png"
-        PILImage.fromarray(image_data).save(image_uri)
+        Image.from_array(image_data, image_uri),
 
         array = wrap(np.random.random_sample((3, 4)))
         data.append(

--- a/python/tests/torch/test_data.py
+++ b/python/tests/torch/test_data.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 import torch
 from pyspark.sql import Row, SparkSession
-from torch.utils.data.dataloader import DataLoader as torchDataLoader
+from torch.utils.data import DataLoader as torchDataLoader
 
 # Rikai
 from rikai.numpy import wrap

--- a/python/tests/torch/test_data.py
+++ b/python/tests/torch/test_data.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 # Third Party
 import numpy as np
+import pytest
+import torch
 from pyspark.sql import Row, SparkSession
 from torch.utils.data.dataloader import DataLoader as torchDataLoader
 
@@ -111,11 +113,13 @@ def test_coco_dataset(
     ), f"Actual annotations: {example[0]['annotations'][0]['bbox']}"
 
 
-def test_torch_dataset(spark: SparkSession, tmp_path: Path):
+@pytest.mark.parametrize("num_workers", [0, 4])
+def test_torch_dataset(spark: SparkSession, tmp_path: Path, num_workers):
     dataset_dir = tmp_path / "data"
     asset_dir = tmp_path / "asset"
     asset_dir.mkdir()
     data = []
+    expected = []
     for i in range(1000):
         image_data = np.random.randint(0, 128, size=(128, 128), dtype=np.uint8)
         image_uri = asset_dir / f"{i}.png"
@@ -129,12 +133,23 @@ def test_torch_dataset(spark: SparkSession, tmp_path: Path):
                 "image": Image(image_uri),
             }
         )
+        expected.append(
+            {
+                "id": i,
+                "array": torch.as_tensor(np.array([array])),
+                "image": torch.as_tensor(np.array([image_data])),
+            }
+        )
 
     df = spark.createDataFrame(data)
-    print(str(dataset_dir))
     df.write.mode("overwrite").format("rikai").save(str(dataset_dir))
 
     dataset = Dataset(str(dataset_dir))
-    loader = torchDataLoader(dataset)
-    actual = list(iter(loader))
+    loader = torchDataLoader(dataset, num_workers=num_workers)
+    actual = sorted(list(loader), key=lambda x: x["id"])
     assert len(actual) == 1000
+    for expect, act in zip(expected, actual):
+        assert torch.equal(
+            expect["array"], act["array"]
+        ), f"Expected {expect['array']} got {act['array']}"
+        assert torch.equal(expect["image"], act["image"])


### PR DESCRIPTION
Pytorch has merged a shuffler that works with IterableDataset, we can limit the scope of `rikai.torch.data` to a Dataset instead. It can leave multi-process loading and shuffling to `pytorch` to handle