### PR TITLE
Upgrade Spark to 3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ developers := List(
 publishMavenStyle := true
 
 libraryDependencies ++= {
-  val sparkVersion = "3.0.1"
+  val sparkVersion = "3.1.1"
   val awsVersion = "2.15.69"
   val log4jScalaVersion = "12.0"
   val log4jVersion = "2.13.0"

--- a/python/setup.py
+++ b/python/setup.py
@@ -41,7 +41,7 @@ setup(
         "pandas",
         "Pillow",
         "pyarrow>=2.0",
-        "pyspark>=3",
+        "pyspark>=3.1,<3.2",
         "requests",
     ],
     extras_require={

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtSparkSQLParser.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtSparkSQLParser.scala
@@ -22,7 +22,12 @@ import org.antlr.v4.runtime.atn.PredictionMode
 import org.antlr.v4.runtime.misc.{Interval, ParseCancellationException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.parser.{ParseErrorListener, ParseException, ParserInterface, PostProcessor}
+import org.apache.spark.sql.catalyst.parser.{
+  ParseErrorListener,
+  ParseException,
+  ParserInterface,
+  PostProcessor
+}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtSparkSQLParser.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtSparkSQLParser.scala
@@ -22,12 +22,7 @@ import org.antlr.v4.runtime.atn.PredictionMode
 import org.antlr.v4.runtime.misc.{Interval, ParseCancellationException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.parser.{
-  ParseErrorListener,
-  ParseException,
-  ParserInterface,
-  PostProcessor
-}
+import org.apache.spark.sql.catalyst.parser.{ParseErrorListener, ParseException, ParserInterface, PostProcessor}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
@@ -127,8 +122,6 @@ private[spark] class RikaiExtSqlParser(
   override def parseDataType(sqlText: String): DataType =
     delegate.parseDataType(sqlText)
 
-  override def parseRawDataType(sqlText: String): DataType =
-    delegate.parseRawDataType(sqlText)
 }
 
 // scalastyle:off line.size.limit

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLParser.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLParser.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.catalyst.parser.{
   AstBuilder,
   ParserInterface
 }
-import org.apache.spark.sql.internal.SQLConf
 
 /**
   * Spark SQL-ML Parser.
@@ -49,7 +48,7 @@ import org.apache.spark.sql.internal.SQLConf
 private[sql] class RikaiSparkSQLParser(
     session: SparkSession,
     delegate: ParserInterface
-) extends AbstractSqlParser(SQLConf.getFallbackConf) {
+) extends AbstractSqlParser {
 
   override protected def astBuilder: AstBuilder =
     new RikaiSparkSQLAstBuilder(session)


### PR DESCRIPTION
Spark 3.1 introduces incompatible changes to `ParserInterface`.  This PR fixes Rikai against to Spark 3.1