### PR TITLE
[SQL] Fix models being not resolvable as attribute

### DIFF
--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLAstBuilder.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLAstBuilder.scala
@@ -81,18 +81,15 @@ private[parser] class RikaiSparkSQLAstBuilder(session: SparkSession)
       }
 
       model match {
-        case Some(m) =>
-          m match {
-            case r: SparkRunnable => r.asSpark(arguments.drop(1))
-            case _ =>
-              throw new ParseException(
-                s"Model ${model} is not runnable in Spark",
-                ctx
-              )
-          }
+        case Some(r: SparkRunnable) => r.asSpark(arguments.drop(1))
         case None =>
           throw new ParseException(
             s"Model ${arguments.head} does not exist",
+            ctx
+          )
+        case _ =>
+          throw new ParseException(
+            s"Model ${model} is not runnable in Spark",
             ctx
           )
       }

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLParser.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLParser.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.catalyst.parser.{
   *    ground_label != ML_PREDICT(old_model, image).label
   * }}}
   *
-  * @param context Contains Rikai runtime information
+  * @param session Contains Rikai runtime information
   * @param delegate the delegated Spark SQL parser.
   */
 private[sql] class RikaiSparkSQLParser(

--- a/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLParserTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLParserTest.scala
@@ -39,10 +39,12 @@ class RikaiSparkSQLParserTest extends AnyFunSuite with SparkTestSession {
   }
 
   test("Test parse ML_PREDICT with catalog") {
-    spark.sql("CREATE MODEL foo USING 'test://host/foo'").show()
+    spark.udf.register("bar", (s: Int) => s + 2)
+
+    spark.sql("CREATE MODEL bar USING 'test://host/bar'").show()
 
     val scores =
-      spark.sql("SELECT id, ML_PREDICT('test://host/foo', id) AS score FROM df")
+      spark.sql("SELECT id, ML_PREDICT(bar, id) AS score FROM df")
 
     val plus_two = udf((v: Int) => v + 2)
     val expected = df.withColumn("score", plus_two(col("id")))


### PR DESCRIPTION
The model that registered with Catalog was not resolvable from later `ML_PREDICT` function because it mistakenly not detect Optional[Model] as return from catalog.