### PR TITLE
video_to_images using Segment

### DIFF
--- a/python/rikai/spark/functions/vision.py
+++ b/python/rikai/spark/functions/vision.py
@@ -100,7 +100,7 @@ def video_to_images(
     video,
     segment: Segment = Segment(0, -1),
     sample_rate: int = 1,
-    max_samples: int = 15000
+    max_samples: int = 15000,
 ) -> list:
     """Extract video frames into a list of images.
     Parameters

--- a/python/rikai/spark/functions/vision.py
+++ b/python/rikai/spark/functions/vision.py
@@ -101,6 +101,7 @@ def video_to_images(
     segment: Segment = Segment(0, -1),
     sample_rate: int = 1,
     max_samples: int = 15000,
+    quality: str = "worst",
 ) -> list:
     """Extract video frames into a list of images.
     Parameters
@@ -113,6 +114,9 @@ def video_to_images(
         The sampling rate in number of frames
     max_samples : Int
         Yield at most this many frames (-1 means no max)
+    quality: str, default 'worst'
+                Either 'worst' (lowest bitrate) or 'best' (highest bitrate)
+                See: https://pythonhosted.org/Pafy/index.html#Pafy.Pafy.getbest
     Return
     ------
     List
@@ -132,7 +136,10 @@ def video_to_images(
     if isinstance(video, YouTubeVideo):
         base_path = video.vid
         video_iterator = SingleFrameSampler(
-            video.get_stream(), sample_rate, start_frame, max_samples
+            video.get_stream(quality=quality),
+            sample_rate,
+            start_frame,
+            max_samples,
         )
     else:
         video_iterator = SingleFrameSampler(

--- a/python/rikai/spark/functions/vision.py
+++ b/python/rikai/spark/functions/vision.py
@@ -100,7 +100,7 @@ def video_to_images(
     video,
     segment: Segment = Segment(0, -1),
     sample_rate: int = 1,
-    max_samples: int = 15000,
+    max_samples: int = 15000
 ) -> list:
     """Extract video frames into a list of images.
     Parameters

--- a/python/rikai/types/video.py
+++ b/python/rikai/types/video.py
@@ -224,7 +224,10 @@ class Segment:
         return isinstance(other, Segment) and (
             self.start_fno,
             self.end_fno,
-        ) == (other.start_fno, other.end_fno,)
+        ) == (
+            other.start_fno,
+            other.end_fno,
+        )
 
 
 class VideoSampler(ABC):

--- a/python/rikai/types/video.py
+++ b/python/rikai/types/video.py
@@ -224,10 +224,7 @@ class Segment:
         return isinstance(other, Segment) and (
             self.start_fno,
             self.end_fno,
-        ) == (
-            other.start_fno,
-            other.end_fno,
-        )
+        ) == (other.start_fno, other.end_fno,)
 
 
 class VideoSampler(ABC):

--- a/python/tests/spark/test_functions.py
+++ b/python/tests/spark/test_functions.py
@@ -33,7 +33,7 @@ from rikai.spark.functions import (
     numpy_to_image,
     video_to_images,
 )
-from rikai.types import Box2d, Image, VideoStream, YouTubeVideo
+from rikai.types import Box2d, Image, VideoStream, YouTubeVideo, Segment
 
 
 def assert_area_equals(array, df):
@@ -139,7 +139,6 @@ def test_video_to_images(spark: SparkSession):
     into list of Image assets.
     """
     sample_rate = 2
-    start_frame = 0
     max_samples = 10
     videostream_df = spark.createDataFrame(
         [
@@ -154,26 +153,27 @@ def test_video_to_images(spark: SparkSession):
                         )
                     )
                 ),
+                Segment(0, 20),
             ),
         ],
-        ["video"],
+        ["video", "segment"],
     )
     youtube_df = spark.createDataFrame(
         [
-            (YouTubeVideo(vid="rUWxSEwctFU"),),
+            (YouTubeVideo(vid="rUWxSEwctFU"), Segment(0, 20)),
         ],
-        ["video"],
+        ["video", "segment"],
     )
     videostream_df = videostream_df.withColumn(
         "images",
         video_to_images(
-            col("video"), lit(sample_rate), lit(start_frame), lit(max_samples)
+            col("video"), col("segment"), lit(sample_rate), lit(max_samples)
         ),
     )
     youtube_df = youtube_df.withColumn(
         "images",
         video_to_images(
-            col("video"), lit(sample_rate), lit(start_frame), lit(max_samples)
+            col("video"), col("segment"), lit(sample_rate), lit(max_samples)
         ),
     )
 

--- a/python/tests/spark/test_functions.py
+++ b/python/tests/spark/test_functions.py
@@ -47,7 +47,11 @@ def assert_area_equals(array, df):
 def test_areas(spark: SparkSession):
     """Test calculating bounding box's area."""
     df = spark.createDataFrame(
-        [(Box2d(1, 2, 2.0, 3.0),), (Box2d(10, 12, 11.0, 17.0),),], ["bbox"],
+        [
+            (Box2d(1, 2, 2.0, 3.0),),
+            (Box2d(10, 12, 11.0, 17.0),),
+        ],
+        ["bbox"],
     )
     df = df.withColumn("area", area(col("bbox")))
     assert_area_equals([1.0, 5.0], df)
@@ -99,7 +103,8 @@ def test_image_copy(spark: SparkSession, tmpdir):
         [(Image(source_image),)], ["image"]
     )  # type: pyspark.sql.DataFrame
     df = df.withColumn(
-        "image", image_copy(col("image"), lit(os.path.join(tmpdir, "out/"))),
+        "image",
+        image_copy(col("image"), lit(os.path.join(tmpdir, "out/"))),
     )
     data = df.collect()  # force lazy calculation
     out_file = os.path.join(tmpdir, "out", "source_image")
@@ -154,7 +159,9 @@ def test_video_to_images(spark: SparkSession):
         ["video", "segment"],
     )
     youtube_df = spark.createDataFrame(
-        [(YouTubeVideo(vid="rUWxSEwctFU"), Segment(0, 20)),],
+        [
+            (YouTubeVideo(vid="rUWxSEwctFU"), Segment(0, 20)),
+        ],
         ["video", "segment"],
     )
     videostream_df = videostream_df.withColumn(

--- a/python/tests/spark/test_functions.py
+++ b/python/tests/spark/test_functions.py
@@ -47,11 +47,7 @@ def assert_area_equals(array, df):
 def test_areas(spark: SparkSession):
     """Test calculating bounding box's area."""
     df = spark.createDataFrame(
-        [
-            (Box2d(1, 2, 2.0, 3.0),),
-            (Box2d(10, 12, 11.0, 17.0),),
-        ],
-        ["bbox"],
+        [(Box2d(1, 2, 2.0, 3.0),), (Box2d(10, 12, 11.0, 17.0),),], ["bbox"],
     )
     df = df.withColumn("area", area(col("bbox")))
     assert_area_equals([1.0, 5.0], df)
@@ -103,8 +99,7 @@ def test_image_copy(spark: SparkSession, tmpdir):
         [(Image(source_image),)], ["image"]
     )  # type: pyspark.sql.DataFrame
     df = df.withColumn(
-        "image",
-        image_copy(col("image"), lit(os.path.join(tmpdir, "out/"))),
+        "image", image_copy(col("image"), lit(os.path.join(tmpdir, "out/"))),
     )
     data = df.collect()  # force lazy calculation
     out_file = os.path.join(tmpdir, "out", "source_image")
@@ -159,9 +154,7 @@ def test_video_to_images(spark: SparkSession):
         ["video", "segment"],
     )
     youtube_df = spark.createDataFrame(
-        [
-            (YouTubeVideo(vid="rUWxSEwctFU"), Segment(0, 20)),
-        ],
+        [(YouTubeVideo(vid="rUWxSEwctFU"), Segment(0, 20)),],
         ["video", "segment"],
     )
     videostream_df = videostream_df.withColumn(


### PR DESCRIPTION
The Kinetics dataset links youtube_ids to video segments labeled by activity:
![image](https://user-images.githubusercontent.com/9044907/111382324-14474a00-8664-11eb-832f-433e36fc9b22.png)

Adding the optional segment argument to `video_to_images` helps deal with variable length video segments. 
![image](https://user-images.githubusercontent.com/9044907/111382209-eb26b980-8663-11eb-907b-bec4417ec455.png)
