### PR TITLE
Reduce the amount of log printed out when initialize Dataset in mulitiple workers

### DIFF
--- a/python/rikai/parquet/dataset.py
+++ b/python/rikai/parquet/dataset.py
@@ -106,7 +106,8 @@ class Dataset:
 
         # Provide deterministic order between distributed workers.
         self.files = sorted(Resolver.resolve(self.uri))
-        logger.info("Loading parquet files: %s", self.files)
+        if self.rank == 0:
+            logger.info("Loading parquet files: %s", self.files)
 
         self.spark_row_metadata = Resolver.get_schema(self.uri)
 


### PR DESCRIPTION
When using `Dataset` with `DataLoader(num_workers=N)`, the list of input parquet files were printed out `N` times.  This PR changes the behavior to only print one time on the worker with `rank==0`