### PR TITLE
Add warnings to deprecate rikai.torch.DataLoader

### DIFF
--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -15,12 +15,14 @@
 """Pytorch Dataset and DataLoader"""
 
 import threading
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from queue import Empty, Queue
 from typing import Callable, Dict, Generator, List, Optional, Union
 
 # Third Party
+import semver
 import torch
 from torch.utils.data import IterableDataset
 
@@ -179,6 +181,15 @@ class DataLoader:
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.collate_fn = collate_fn if collate_fn else lambda x: x
+
+        torch_version = semver.VersionInfo.parse(torch.__version__)
+        if torch_version.major >= 1 and torch_version.minor >= 8:
+            warnings.warn(
+                "rikai.torch.data.DataLoader should be replaced with "
+                "'torch.utils.data.BufferedShuffleDataset' and 'torch.utils.data.DataLoader' "
+                "in Pytorch 1.8+",
+                DeprecationWarning,
+            )
 
     def _prefetch(
         self, out_queue: Queue, done: threading.Event, stop: threading.Event

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -193,7 +193,8 @@ class DataLoader:
         if torch_version.major >= 1 and torch_version.minor >= 8:
             warnings.warn(
                 "rikai.torch.data.DataLoader should be replaced with "
-                "'torch.utils.data.BufferedShuffleDataset' and 'torch.utils.data.DataLoader' "
+                "'torch.utils.data.BufferedShuffleDataset' and "
+                "'torch.utils.data.DataLoader' "
                 "in Pytorch 1.8+",
                 DeprecationWarning,
             )

--- a/python/rikai/torch/data.py
+++ b/python/rikai/torch/data.py
@@ -152,6 +152,13 @@ class DataLoader:
             for batch_idx, (data, target) in enumerate(train_loader):
                 ...
 
+    .. warning::
+
+        With Pytorch 1.8+, users should use the official :py:class:`torch.utils.data.DataLoader`
+        with :py:class:`torch.utils.data.BufferedShuffleDataset` instead.
+
+        This class will be deprecated later.
+
     References
     ----------
     .. `Horovod with Pytorch <https://horovod.readthedocs.io/en/stable/pytorch.html>`_

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,6 @@
 import pathlib
 import re
+
 from setuptools import find_packages, setup
 
 about = {}
@@ -46,6 +47,7 @@ setup(
         "pyspark>=3.1,<3.2",
         "pyyaml",
         "requests",
+        "semver",
     ],
     extras_require={
         "test": test,


### PR DESCRIPTION
After introducing `BufferedShuffleDataset` in Pytorch 1.8,  the official DataLoader can shuffle an IterableDataset (a.k.a, Rikai's parquet Dataset). Therefore, we dont need implement DataLoader by ourselves.

This PR starts to show warnings to alert users to use torch's DataLoader if they are using pytorch 1.8+