### PR TITLE
add sbt-ci-release

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,6 +15,8 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Setup Scala
       uses: olafurpg/setup-scala@v10
       with:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -12,6 +12,8 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
       # with:
       #   lfs: true
     # - name: Checkout LFS objects

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,11 @@ scalaVersion := "2.12.11"
 name := "rikai"
 
 def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
+  val parts = out.ref.dropPrefix.split('.').toList
+  val major :: minor :: patch :: rest = parts
+  val nextPatchInt = patch.toInt + 1
   if (out.isSnapshot)
-    out.ref.dropPrefix + "-SNAPSHOT"
+    s"$major.$minor.$nextPatchInt-SNAPSHOT"
   else
     out.ref.dropPrefix
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,27 +1,30 @@
-import ReleaseTransformations._
-
 scalaVersion := "2.12.11"
-
 name := "rikai"
 
-organization := "ai.eto"
-homepage := Some(url("https://github.com/eto-ai/rikai"))
+inThisBuild(
+  List(
+    organization := "ai.eto",
+    homepage := Some(url("https://github.com/eto-ai/rikai")),
+    licenses := List(
+      "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
+    ),
+    developers := List(
+      Developer(
+        "rikai-dev",
+        "Rikai Developers",
+        "rikai-dev@eto.ai",
+        url("https://github.com/eto-ai/rikai")
+      )
+    )
+  )
+)
+
 scmInfo := Some(
   ScmInfo(
     url("https://github.com/eto-ai/rikai"),
     "git@github.com:eto-ai/rikai.git"
   )
 )
-licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
-developers := List(
-  Developer(
-    "rikai",
-    "developers",
-    "rikai-dev@eto.ai",
-    url("https://github.com/eto-ai/rikai")
-  )
-)
-publishMavenStyle := true
 
 libraryDependencies ++= {
   val sparkVersion = "3.1.1"
@@ -60,24 +63,6 @@ scalacOptions ++= Seq(
 )
 
 Test / parallelExecution := false
-
-publishTo := sonatypePublishToBundle.value
-
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
-releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,
-  inquireVersions,
-  runClean,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  releaseStepCommandAndRemaining("publishSigned"),
-  releaseStepCommand("sonatypeBundleRelease"),
-  setNextVersion,
-  commitNextVersion,
-  pushChanges
-)
 
 antlr4PackageName in Antlr4 := Some("ai.eto.rikai.sql.spark.parser")
 antlr4GenVisitor in Antlr4 := true

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,16 @@
 scalaVersion := "2.12.11"
 name := "rikai"
 
+def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
+  if (out.isSnapshot)
+    out.ref.dropPrefix + "-SNAPSHOT"
+  else
+    out.ref.dropPrefix
+}
+
+def fallbackVersion(d: java.util.Date): String =
+  s"HEAD-${sbtdynver.DynVer timestamp d}"
+
 inThisBuild(
   List(
     organization := "ai.eto",
@@ -15,7 +25,15 @@ inThisBuild(
         "rikai-dev@eto.ai",
         url("https://github.com/eto-ai/rikai")
       )
-    )
+    ),
+    version := dynverGitDescribeOutput.value
+      .mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value)),
+    dynver := {
+      val d = new java.util.Date
+      sbtdynver.DynVer
+        .getGitDescribeOutput(d)
+        .mkVersion(versionFmt, fallbackVersion(d))
+    }
   )
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.6")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")

--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -6,7 +6,7 @@ parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?(\.(?P<release>[a-z]+)(
 serialize =
 	{major}.{minor}.{patch}.{release}{build}
 	{major}.{minor}.{patch}
-message = "Bump version for python package: {current_version} -> {new_version} [skip ci]"
+message = "Bump version for python package: {current_version} -> {new_version}"
 
 [bumpversion:part:release]
 first_value = dev

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.0.4-SNAPSHOT"


### PR DESCRIPTION
replace sbt-release plugin with sbt-ci-release plugin to prepare for using GH actions to release rikai.
one change is that this uses sbt dynver (tag-based) instead.

If you're unfamiliar how that works, checkout the example below:

```
(eto) λ ~/code/eto/rikai/ sbt-ci-release git tag v0.0.4
(eto) λ ~/code/eto/rikai/ sbt-ci-release git tag
(eto) λ ~/code/eto/rikai/ sbt-ci-release sbt "show dynver"
[info] Loading settings for project global-plugins from plugins.sbt,idea.sbt,gpg.sbt ...
[info] Loading global plugins from /home/chang/.sbt/1.0/plugins
[info] Loading settings for project rikai-build from plugins.sbt,sbt-antlr4.sbt ...
[info] Loading project definition from /home/chang/code/eto/rikai/project
[info] Loading settings for project rikai from build.sbt ...
[info] Set current project to rikai (in build file:/home/chang/code/eto/rikai/)
[info] 0.0.4
[success] Total time: 0 s, completed Mar 29, 2021, 4:37:23 PM

(eto) λ ~/code/eto/rikai/ sbt-ci-release git tag -d v0.0.4
Deleted tag 'v0.0.4' (was 47966ee)
(eto) λ ~/code/eto/rikai/ sbt-ci-release sbt "show dynver"
[info] Loading settings for project global-plugins from plugins.sbt,idea.sbt,gpg.sbt ...
[info] Loading global plugins from /home/chang/.sbt/1.0/plugins
[info] Loading settings for project rikai-build from plugins.sbt,sbt-antlr4.sbt ...
[info] Loading project definition from /home/chang/code/eto/rikai/project
[info] Loading settings for project rikai from build.sbt ...
[info] Set current project to rikai (in build file:/home/chang/code/eto/rikai/)
[info] 0.0.3-SNAPSHOT
[success] Total time: 0 s, completed Mar 29, 2021, 4:38:01 PM
```