### PR TITLE
Create scala-publish

### DIFF
--- a/.github/workflows/scala-publish
+++ b/.github/workflows/scala-publish
@@ -1,0 +1,20 @@
+name: Publish Jar to Sonatype
+on:
+  release:
+    types: [created]
+    
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - uses: olafurpg/setup-scala@v10
+      - uses: olafurpg/setup-gpg@v3
+      - run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
workflow based on sbt-ci-release template

note that the template (https://github.com/olafurpg/sbt-ci-release/blob/main/.github/workflows/release.yml)
also publishes SNAPSHOT artifacts whereas this PR does not