### PR TITLE
Add bumpversion to control version and tag releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ fix:
 
 # increment to the next released version and add a release tag
 release:
-  cd python && bumpversion release --tag
+	cd python && bumpversion release --tag
 .PHONY: release
 
 # from a release build go to the next patch
 patch:
-  cd python && bumpversion patch
+	cd python && bumpversion patch
 .PHONY: patch

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,13 @@ fix:
 	sbt scalafmt
 	black -l 79 python/rikai python/tests
 .PHONY: fix
+
+# increment to the next released version and add a release tag
+release:
+  cd python && bumpversion release --tag
+.PHONY: release
+
+# from a release build go to the next patch
+patch:
+  cd python && bumpversion patch
+.PHONY: patch

--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,10 +1,10 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = 0.0.4dev0
-parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?((?P<release>[a-z]+)(?P<build>\d+))?
+current_version = 0.0.4.dev0
+parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?(\.(?P<release>[a-z]+)(?P<build>\d+))?
 serialize =
-	{major}.{minor}.{patch}{release}{build}
+	{major}.{minor}.{patch}.{release}{build}
 	{major}.{minor}.{patch}
 message = "Bump version for python package: {current_version} -> {new_version} [skip ci]"
 

--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,0 +1,18 @@
+[bumpversion]
+commit = True
+tag = False
+current_version = 0.0.4dev0
+parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?((?P<release>[a-z]+)(?P<build>\d+))?
+serialize =
+	{major}.{minor}.{patch}{release}{build}
+	{major}.{minor}.{patch}
+message = "Bump version for python package: {current_version} -> {new_version} [skip ci]"
+
+[bumpversion:part:release]
+first_value = dev
+optional_value = final
+values =
+	dev
+	final
+
+[bumpversion:file:./rikai/__version__.py]

--- a/python/rikai/__version__.py
+++ b/python/rikai/__version__.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-version = "0.0.4dev0"
+version = "0.0.4.dev0"

--- a/python/rikai/__version__.py
+++ b/python/rikai/__version__.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-version = "0.0.4.dev0"
+version = "0.0.4dev0"

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,14 +13,14 @@ with open(
     long_description = fh.read()
 
 # extras
-test = ["pytest"]
+dev = ["pytest", "bump2version"]
 torch = ["torch>=1.4.0", "torchvision"]
 jupyter = ["matplotlib", "jupyterlab"]
 aws = ["boto"]
 gcp = ["gcsfs"]
 docs = ["sphinx"]
 youtube = ["pafy", "youtube_dl", "ffmpeg-python"]
-all = test + torch + jupyter + aws + gcp + docs + youtube
+all = dev + torch + jupyter + aws + gcp + docs + youtube
 
 
 setup(
@@ -50,7 +50,7 @@ setup(
         "semver",
     ],
     extras_require={
-        "test": test,
+        "dev": dev,
         "pytorch": torch,
         "jupyter": jupyter,
         "aws": aws,


### PR DESCRIPTION

Make a release:
```
(eto) λ ~/code/eto/rikai/python/ bumpversion grep "version" rikai/__version__.py
version = "0.0.4dev0"
(eto) λ ~/code/eto/rikai/python/ bumpversion bumpversion release --tag
(eto) λ ~/code/eto/rikai/python/ bumpversion grep "version" rikai/__version__.py
version = "0.0.4"
```

Bump to next dev build:
```
(eto) λ ~/code/eto/rikai/python/ bumpversion bumpversion patch
(eto) λ ~/code/eto/rikai/python/ bumpversion grep "version" rikai/__version__.py
version = "0.0.5dev0"
```

Above two interactions results in following commits (doesn't automatically push).
And note that you must specify the `--tag` option to create the tag.
```
(eto) λ ~/code/eto/rikai/python/ bumpversion git log
commit 792a422c4b9998e1165e58205f0041b0d6cade82 (HEAD -> bumpversion)
Author: changhiskhan <changshe@gmail.com>
Date:   Mon Mar 29 17:22:56 2021 -0700

    "Bump version for python package: 0.0.4 -> 0.0.5dev0 [skip ci]"

commit 298381e2ba3f69526e7b08b554c0af568cdf81d2 (tag: v0.0.4)
Author: changhiskhan <changshe@gmail.com>
Date:   Mon Mar 29 17:19:25 2021 -0700

    "Bump version for python package: 0.0.4dev0 -> 0.0.4 [skip ci]"
```

So putting everything together, the release workflow will be:

1. [GITHUB UI] Make sure head of master is green
2. [LOCAL] Checkout latest on master locally
3. [LOCAL] `bumpversion release --tag`
4. [LOCAL] git push origin master
5. [GITHUB UI] Create a new release in GH based on the tag
6. [GITHUB ACTIONS] publish-python and publish-scala workflows kick off to publish artifacts (triggered by creating the release in step 5)
7. [LOCAL] `bumpversion patch` to go to next dev build
8. [LOCAL] git push origin master