### PR TITLE
[TST] tweak test setup to diagnose timeout issue

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,8 +30,7 @@ jobs:
       working-directory: python
       run: |
         sudo apt-get -y -qq install libsnappy-dev ffmpeg
-        python -m pip install -q wheel pylint black flake8
-        python -m pip install -e .[all]
+        python -m pip install -e .[all,dev]
     - name: Python black and flake8
       if: ${{ matrix.python-version == 3.8 }}
       run: make lint
@@ -42,7 +41,7 @@ jobs:
     - name: Run python tests
       working-directory: python
       run: |
-        pytest --ignore=tests/parquet/internal
+        pytest -v --duration=10 --ignore=tests/parquet/internal
   mac-build:
     runs-on: macos-latest
     timeout-minutes: 10
@@ -59,6 +58,5 @@ jobs:
     - name: Test Pip install
       working-directory: python
       run: |
-        python -m pip install -q wheel
         python setup.py bdist_wheel
         python -m pip install $(ls dist/rikai*.whl)

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Run python tests
       working-directory: python
       run: |
-        pytest -v --duration=10 --ignore=tests/parquet/internal
+        pytest -v --durations=10 --ignore=tests/parquet/internal
   mac-build:
     runs-on: macos-latest
     timeout-minutes: 10

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,5 +58,6 @@ jobs:
     - name: Test Pip install
       working-directory: python
       run: |
+        python -m pip install -q wheel
         python setup.py bdist_wheel
         python -m pip install $(ls dist/rikai*.whl)

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,14 +13,15 @@ with open(
     long_description = fh.read()
 
 # extras
-dev = ["pytest", "bump2version"]
+dev = ["black", "bump2version", "flake8", "isort", "pylint", "pytest",
+       "pytest-timeout", "wheel"]
 torch = ["torch>=1.4.0", "torchvision"]
 jupyter = ["matplotlib", "jupyterlab"]
 aws = ["boto"]
 gcp = ["gcsfs"]
 docs = ["sphinx"]
 youtube = ["pafy", "youtube_dl", "ffmpeg-python"]
-all = dev + torch + jupyter + aws + gcp + docs + youtube
+all = torch + jupyter + aws + gcp + docs + youtube
 
 
 setup(

--- a/python/tests/torch/test_data.py
+++ b/python/tests/torch/test_data.py
@@ -119,6 +119,7 @@ def test_coco_dataset(
 
 
 # @pytest.mark.parametrize("num_workers", [0, 2, 4])
+@pytest.mark.timeout(30)
 @pytest.mark.parametrize("num_workers", [0])  # Still hangs
 def test_torch_dataset(spark, tmp_path, num_workers):
     total = 1000


### PR DESCRIPTION
Add pytest-timing to add a 30s timeout for dataloader test.
Change `test` extras to `dev` extras and exclude it from `all` (need to update docs later)
Add verbose and timing printing to pytest command