### PR TITLE
Pass through image options when saving images

### DIFF
--- a/python/rikai/spark/functions/vision.py
+++ b/python/rikai/spark/functions/vision.py
@@ -86,9 +86,9 @@ def numpy_to_image(
         The base directory to copy the image to.
     format : str, optional
         The image format to save as. See
-        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details. #pylint: disable=line-too-long
+        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details.
     kwargs : dict, optional
-        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_. #pylint: disable=line-too-long
+        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_.
 
     Return
     ------
@@ -108,7 +108,7 @@ def numpy_to_image(
     See Also
     --------
     :py:meth:`rikai.types.vision.Image.from_array`
-    """
+    """  # noqa: E501
     return Image.from_array(array, uri, format=format, **kwargs)
 
 
@@ -142,15 +142,15 @@ def video_to_images(
         See: https://pythonhosted.org/Pafy/index.html#Pafy.Pafy.getbest
     img_format : str, optional
         The image format to save as. See
-        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details. #pylint: disable=line-too-long
+        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details.
     img_kwargs : dict, optional
-        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_. #pylint: disable=line-too-long
+        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_.
 
     Return
     ------
     List
         Return a list of images from video indexed by frame number.
-    """
+    """  # noqa: E501
     assert isinstance(
         video, (YouTubeVideo, VideoStream)
     ), "Input type must be YouTubeVideo or VideoStream"
@@ -212,15 +212,15 @@ def spectrogram_image(
         Sets resolution of frequency, time spectrogram image.
     img_format : str, optional
         The image format to save as. See
-        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details. #pylint: disable=line-too-long
+        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details.
     img_kwargs : dict, optional
-        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_. #pylint: disable=line-too-long
+        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_.
 
     Return
     ------
     Image
         Return an Image of the audio spectrogram.
-    """
+    """  # noqa: E501
     try:
         import ffmpeg
     except ImportError:

--- a/python/rikai/spark/functions/vision.py
+++ b/python/rikai/spark/functions/vision.py
@@ -120,8 +120,8 @@ def video_to_images(
     sample_rate: int = 1,
     max_samples: int = 15000,
     quality: str = "worst",
-    img_format: str = "png",
-    **img_kwargs,
+    image_format: str = "png",
+    **image_kwargs,
 ) -> list:
     """Extract video frames into a list of images.
 
@@ -140,10 +140,10 @@ def video_to_images(
     quality: str, default 'worst'
         Either 'worst' (lowest bitrate) or 'best' (highest bitrate)
         See: https://pythonhosted.org/Pafy/index.html#Pafy.Pafy.getbest
-    img_format : str, optional
+    image_format : str, optional
         The image format to save as. See
         `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details.
-    img_kwargs : dict, optional
+    image_kwargs : dict, optional
         Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_.
 
     Return
@@ -177,10 +177,12 @@ def video_to_images(
             img,
             os.path.join(
                 output_uri,
-                "{}.{}".format((start_frame + idx) * sample_rate, img_format),
+                "{}.{}".format(
+                    (start_frame + idx) * sample_rate, image_format
+                ),
             ),
-            format=img_format,
-            **img_kwargs,
+            format=image_format,
+            **image_kwargs,
         )
         for idx, img in enumerate(video_iterator)
     ]
@@ -193,8 +195,8 @@ def spectrogram_image(
     segment: Segment = Segment(0, -1),
     size: int = 224,
     max_samples: int = 15000,
-    img_format: str = None,
-    **img_kwargs,
+    image_format: str = None,
+    **image_kwargs,
 ) -> Image:
     """Applies ffmpeg filter to generate spectrogram image.
 
@@ -210,10 +212,10 @@ def spectrogram_image(
             Yield at most this many frames (-1 means no max)
     size : Int
         Sets resolution of frequency, time spectrogram image.
-    img_format : str, optional
+    image_format : str, optional
         The image format to save as. See
         `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details.
-    img_kwargs : dict, optional
+    image_kwargs : dict, optional
         Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_.
 
     Return
@@ -257,6 +259,6 @@ def spectrogram_image(
     return Image.from_array(
         np.frombuffer(output, np.uint8).reshape([size, size, 3]),
         output_uri,
-        format=img_format,
-        **img_kwargs,
+        format=image_format,
+        **image_kwargs,
     )

--- a/python/rikai/spark/functions/vision.py
+++ b/python/rikai/spark/functions/vision.py
@@ -86,9 +86,9 @@ def numpy_to_image(
         The base directory to copy the image to.
     format : str, optional
         The image format to save as. See
-        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details.
+        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details. #pylint: disable=line-too-long
     kwargs : dict, optional
-        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_.
+        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_. #pylint: disable=line-too-long
 
     Return
     ------
@@ -142,9 +142,9 @@ def video_to_images(
         See: https://pythonhosted.org/Pafy/index.html#Pafy.Pafy.getbest
     img_format : str, optional
         The image format to save as. See
-        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details.
+        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details. #pylint: disable=line-too-long
     img_kwargs : dict, optional
-        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_.
+        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_. #pylint: disable=line-too-long
 
     Return
     ------
@@ -212,9 +212,9 @@ def spectrogram_image(
         Sets resolution of frequency, time spectrogram image.
     img_format : str, optional
         The image format to save as. See
-        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details.
+        `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details. #pylint: disable=line-too-long
     img_kwargs : dict, optional
-        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_.
+        Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_. #pylint: disable=line-too-long
 
     Return
     ------

--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -107,7 +107,7 @@ class Image(ToNumpy, ToPIL, Asset, Displayable):
             `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details.
         kwargs : dict, optional
             Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_.
-        """
+        """  # noqa: E501
         parsed = urlparse(normalize_uri(uri))
         if parsed.scheme == "file":
             img.save(uri, format=format, **kwargs)

--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -59,6 +59,8 @@ class Image(ToNumpy, ToPIL, Asset, Displayable):
         array: np.ndarray,
         uri: Union[str, Path],
         mode: str = None,
+        format: str = None,
+        **kwargs,
     ) -> Image:
         """Create an image in memory from numpy array.
 
@@ -71,6 +73,11 @@ class Image(ToNumpy, ToPIL, Asset, Displayable):
         mode : str, optional
             The mode which PIL used to create image. See supported
             `modes on PIL document <https://pillow.readthedocs.io/en/stable/handbook/concepts.html#concept-modes>`_.
+        format : str, optional
+            The image format to save as. See
+            `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details.
+        kwargs : dict, optional
+            Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_.
 
         See Also
         --------
@@ -81,10 +88,12 @@ class Image(ToNumpy, ToPIL, Asset, Displayable):
 
         assert array is not None
         img = PILImage.fromarray(array, mode=mode)
-        return cls.from_pil(img, uri)
+        return cls.from_pil(img, uri, format=format, **kwargs)
 
     @staticmethod
-    def from_pil(img: PILImage, uri: Union[str, Path]) -> Image:
+    def from_pil(
+        img: PILImage, uri: Union[str, Path], format: str = None, **kwargs
+    ) -> Image:
         """Create an image in memory from a :py:class:`PIL.Image`.
 
         Parameters
@@ -93,13 +102,18 @@ class Image(ToNumpy, ToPIL, Asset, Displayable):
             An PIL Image instance
         uri : str or Path
             The URI to store the image externally.
+        format : str, optional
+            The image format to save as. See
+            `supported formats <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_ for details.
+        kwargs : dict, optional
+            Optional arguments to pass to `PIL.Image.save <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>`_.
         """
         parsed = urlparse(normalize_uri(uri))
         if parsed.scheme == "file":
-            img.save(uri)
+            img.save(uri, format=format, **kwargs)
         else:
             with NamedTemporaryFile() as fobj:
-                img.save(fobj)
+                img.save(fobj, format=format, **kwargs)
                 fobj.flush()
                 copy(fobj.name, uri)
         return Image(uri)

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from binascii import b2a_base64
+import filecmp
 
 import numpy as np
 import pytest
@@ -42,6 +43,29 @@ def test_show_embedded_jpeg(tmp_path):
     with open(uri, "rb") as fh:
         expected = b2a_base64(fh.read()).decode("ascii")
         assert result == expected
+
+
+def test_format_kwargs(tmp_path):
+    data = np.random.random((100, 100))
+    rescaled = (255.0 / data.max() * (data - data.min())).astype(np.uint8)
+    result_uri = str(tmp_path / "result.jpg")
+    Image.from_array(rescaled, result_uri, format="jpeg", optimize=True)
+
+    expected_uri = str(tmp_path / "expected.jpg")
+    PILImage.fromarray(rescaled).save(
+        expected_uri, format="jpeg", optimize=True
+    )
+
+    assert filecmp.cmp(result_uri, expected_uri)
+
+    result_uri = str(tmp_path / "result.png")
+    Image.from_array(rescaled, result_uri, format="png", compress_level=1)
+
+    expected_uri = str(tmp_path / "expected.png")
+    PILImage.fromarray(rescaled).save(
+        expected_uri, format="png", compress_level=1
+    )
+    assert filecmp.cmp(result_uri, expected_uri)
 
 
 @pytest.mark.timeout(30)

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -48,20 +48,20 @@ def test_show_embedded_jpeg(tmp_path):
 def test_format_kwargs(tmp_path):
     data = np.random.random((100, 100))
     rescaled = (255.0 / data.max() * (data - data.min())).astype(np.uint8)
-    result_uri = str(tmp_path / "result.jpg")
+    result_uri = tmp_path / "result.jpg"
     Image.from_array(rescaled, result_uri, format="jpeg", optimize=True)
 
-    expected_uri = str(tmp_path / "expected.jpg")
+    expected_uri = tmp_path / "expected.jpg"
     PILImage.fromarray(rescaled).save(
         expected_uri, format="jpeg", optimize=True
     )
 
     assert filecmp.cmp(result_uri, expected_uri)
 
-    result_uri = str(tmp_path / "result.png")
+    result_uri = tmp_path / "result.png"
     Image.from_array(rescaled, result_uri, format="png", compress_level=1)
 
-    expected_uri = str(tmp_path / "expected.png")
+    expected_uri = tmp_path / "expected.png"
     PILImage.fromarray(rescaled).save(
         expected_uri, format="png", compress_level=1
     )


### PR DESCRIPTION
When we save images via PIL, there are lots of ways to parametrize.
https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save