### PR TITLE
Abstract out ModelSpec

### DIFF
--- a/python/rikai/spark/sql/codegen/base.py
+++ b/python/rikai/spark/sql/codegen/base.py
@@ -12,8 +12,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import secrets
 from abc import ABC, abstractmethod
-from typing import Dict
+from typing import Any, Callable, Dict, IO, Mapping, Optional, Union
+
+import pandas as pd
+from pyspark.sql import SparkSession
+from pyspark.sql.types import DataType
+
+from rikai.logging import logger
+from rikai.spark.sql.exceptions import SpecError
 
 
 class Registry(ABC):
@@ -33,3 +41,88 @@ class Registry(ABC):
         options: dict
             Additional options passed to the model.
         """
+
+
+class ModelSpec(ABC):
+    """Base class of a Model spec"""
+
+    @abstractmethod
+    def validate(self):
+        """Validate model spec
+
+        Raises
+        ------
+        SpecError
+            If the spec is not well-formatted.
+        """
+
+    @property
+    @abstractmethod
+    def version(self) -> str:
+        """Returns spec version."""
+
+    @property
+    @abstractmethod
+    def uri(self) -> str:
+        """Return Model URI"""
+
+    @property
+    @abstractmethod
+    def flavor(self) -> str:
+        """Model flavor"""
+
+    @property
+    @abstractmethod
+    def schema(self) -> DataType:
+        """Return the output schema of the model."""
+
+    @property
+    @abstractmethod
+    def options(self) -> Dict[str, str]:
+        """Model options"""
+
+    @property
+    @abstractmethod
+    def pre_processing(self) -> Optional[Callable]:
+        """Return pre-processing transform if exists"""
+
+    @property
+    @abstractmethod
+    def post_processing(self) -> Optional[Callable]:
+        """Return post-processing transform if exists"""
+
+
+def udf_from_spec(spec: ModelSpec):
+    """Return a UDF from a given ModelSpec
+
+    Parameters
+    ----------
+    spec : ModelSpec
+        A model spec
+
+    Returns
+    -------
+    str
+        Spark UDF function name for the generated data.
+    """
+    if spec.version != "1.0":
+        raise SpecError(
+            f"Only spec version 1.0 is supported, got {spec.version}"
+        )
+
+    if spec.flavor == "pytorch":
+        from rikai.spark.sql.codegen.pytorch import generate_udf
+
+        return generate_udf(spec)
+    else:
+        raise SpecError(f"Unsupported model flavor: {spec.flavor}")
+
+
+def register_udf(spark: SparkSession, udf: Callable, name: str) -> str:
+    """
+    Register a given UDF with the give Spark session under the given name.
+    """
+    func_name = f"{name}_{secrets.token_hex(4)}"
+    spark.udf.register(func_name, udf)
+    logger.info(f"Created model inference pandas_udf with name {func_name}")
+    return func_name

--- a/python/tests/spark/sql/codegen/test_fs.py
+++ b/python/tests/spark/sql/codegen/test_fs.py
@@ -28,7 +28,7 @@ from pyspark.sql.types import (
     StructType,
 )
 
-from rikai.spark.sql.codegen.fs import ModelSpec
+from rikai.spark.sql.codegen.fs import FileModelSpec
 from rikai.spark.sql.exceptions import SpecError
 from rikai.spark.sql.schema import parse_schema
 
@@ -47,7 +47,7 @@ def resnet_spec(tmp_path_factory):
     torch.save(resnet, model_uri)
 
     spec_yaml = """
-version: 1.0
+version: "1.0"
 name: resnet
 model:
   uri: {}
@@ -67,9 +67,9 @@ transforms:
 
 
 def test_validate_yaml_spec():
-    ModelSpec(
+    FileModelSpec(
         {
-            "version": 1.2,
+            "version": "1.2",
             "name": "test_yaml_model",
             "schema": "long",
             "model": {
@@ -86,10 +86,10 @@ def test_validate_yaml_spec():
 
 def test_validate_misformed_spec():
     with pytest.raises(SpecError):
-        ModelSpec({})
+        FileModelSpec({})
 
     with pytest.raises(SpecError, match=".*version' is a required property.*"):
-        ModelSpec(
+        FileModelSpec(
             {
                 "name": "test_yaml_model",
                 "schema": "long",
@@ -98,18 +98,18 @@ def test_validate_misformed_spec():
         )
 
     with pytest.raises(SpecError, match=".*'model' is a required property.*"):
-        ModelSpec(
+        FileModelSpec(
             {
-                "version": 1.0,
+                "version": "1.0",
                 "name": "test_yaml_model",
                 "schema": "long",
             },
         )
 
     with pytest.raises(SpecError, match=".*'uri' is a required property.*"):
-        ModelSpec(
+        FileModelSpec(
             {
-                "version": 1.0,
+                "version": "1.0",
                 "name": "test_yaml_model",
                 "schema": "long",
                 "model": {},

--- a/python/tests/spark/test_callback_service.py
+++ b/python/tests/spark/test_callback_service.py
@@ -27,7 +27,7 @@ def test_cb_service_find_registry(spark: SparkSession, tmp_path: Path):
     with spec_file.open("w") as fobj:
         fobj.write(
             """
-version: 1.0
+version: "1.0"
 schema: long
 model:
     uri: abc.pt


### PR DESCRIPTION
1. Make ModelSpec an ABC that can be derived by different types of Registries
2. Change the YAML model version property from number to string (e.g., don't want to deal with floating point precision)

This is a preparatory refactor to adding MLFlow Registry