### PR TITLE
Implement shortcut for rikai format on spark dataframe I/O

### DIFF
--- a/src/main/scala/ai/eto/rikai/package.scala
+++ b/src/main/scala/ai/eto/rikai/package.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Rikai authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.eto
+
+import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter}
+
+package object rikai {
+  implicit class RikaiReader(reader: DataFrameReader) {
+    def rikai(path: String): DataFrame = {
+      reader.format("rikai").load(path)
+    }
+  }
+
+  implicit class RikaiWriter[T](writer: DataFrameWriter[T]) {
+    def rikai(path: String): Unit = {
+      writer.format("rikai").save(path)
+    }
+  }
+}

--- a/src/main/scala/ai/eto/rikai/package.scala
+++ b/src/main/scala/ai/eto/rikai/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Rikai authors
+ * Copyright 2021 Rikai authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/ai/eto/rikai/sql/package.scala
+++ b/src/main/scala/ai/eto/rikai/sql/package.scala
@@ -16,6 +16,8 @@
 
 package ai.eto.rikai
 
+import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter}
+
 /**
   * Rikai SQL-ML extension.
   *
@@ -40,4 +42,16 @@ package ai.eto.rikai
   *
   * {{{ SELECT id, ML_PREDICT(model_name, col1, col2, col3) as predicted FROM table }}}
   */
-package object sql {}
+package object sql {
+  implicit class RikaiReader(reader: DataFrameReader) {
+    def rikai(path: String): DataFrame = {
+      reader.format("rikai").load(path)
+    }
+  }
+
+  implicit class RikaiWriter[T](writer: DataFrameWriter[T]) {
+    def rikai(path: String): Unit = {
+      writer.format("rikai").save(path)
+    }
+  }
+}

--- a/src/main/scala/ai/eto/rikai/sql/package.scala
+++ b/src/main/scala/ai/eto/rikai/sql/package.scala
@@ -16,8 +16,6 @@
 
 package ai.eto.rikai
 
-import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter}
-
 /**
   * Rikai SQL-ML extension.
   *
@@ -42,16 +40,4 @@ import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter}
   *
   * {{{ SELECT id, ML_PREDICT(model_name, col1, col2, col3) as predicted FROM table }}}
   */
-package object sql {
-  implicit class RikaiReader(reader: DataFrameReader) {
-    def rikai(path: String): DataFrame = {
-      reader.format("rikai").load(path)
-    }
-  }
-
-  implicit class RikaiWriter[T](writer: DataFrameWriter[T]) {
-    def rikai(path: String): Unit = {
-      writer.format("rikai").save(path)
-    }
-  }
-}
+package object sql {}

--- a/src/test/scala/ai/eto/rikai/RikaiRelationTest.scala
+++ b/src/test/scala/ai/eto/rikai/RikaiRelationTest.scala
@@ -26,36 +26,35 @@ class RikaiRelationTest extends AnyFunSuite with SparkTestSession {
 
   import spark.implicits._
 
-  val examples = Seq(
+  private val examples = Seq(
     ("123", "car"),
     ("123", "people"),
     ("246", "tree")
   ).toDF("id", "label")
 
-  val testDir =
-    new File(Files.createTempDirectory("rikai").toFile(), "dataset")
+  private val testDir =
+    new File(Files.createTempDirectory("rikai").toFile, "dataset")
 
   test("Use rikai registered as the sink of spark") {
-    examples.write.format("rikai").save(testDir.toString())
+    examples.write.format("rikai").save(testDir.toString)
 
     val numParquetFileds =
-      testDir.list().filter(_.endsWith(".parquet")).length
+      testDir.list().count(_.endsWith(".parquet"))
     assert(numParquetFileds > 0)
 
-    val df = spark.read.parquet(testDir.toString())
+    val df = spark.read.parquet(testDir.toString)
     assert(df.intersectAll(examples).count == 3)
   }
 
   test("Use rikai reader and writer") {
-    import ai.eto.rikai.sql.RikaiWriter
-    examples.write.rikai(testDir.toString())
+    import ai.eto.rikai._
+    examples.write.rikai(testDir.toString)
 
     val numParquetFileds =
-      testDir.list().filter(_.endsWith(".parquet")).length
+      testDir.list().count(_.endsWith(".parquet"))
     assert(numParquetFileds > 0)
 
-    import ai.eto.rikai.sql.RikaiReader
-    val df = spark.read.rikai(testDir.toString())
+    val df = spark.read.rikai(testDir.toString)
     assert(df.intersectAll(examples).count == 3)
   }
 }


### PR DESCRIPTION
Close #172 

## Why `io.eto.rikai` but not `io.eto.rikai.sql`
``` scala
import io.eto.rikai.sql._

spark // The Spark Session will be overrided by io.eto.rikai.sql.spark
```

``` scala
import io.eto.rikai._

spark.read.rikai("xxx") // works fine
spark.write.rikai("yyy") // works fine
```