### PR TITLE
Fix setting options in FileSystemModelSpec and clean up import

### DIFF
--- a/python/rikai/spark/sql/codegen/base.py
+++ b/python/rikai/spark/sql/codegen/base.py
@@ -14,17 +14,18 @@
 
 import secrets
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, IO, Mapping, Optional, Union
+from typing import Any, Callable, Dict, Optional
 
-import pandas as pd
 from jsonschema import validate, ValidationError
 from pyspark.sql import SparkSession
-from pyspark.sql.types import DataType
 
 from rikai.internal.reflection import find_class
 from rikai.logging import logger
 from rikai.spark.sql.exceptions import SpecError
 from rikai.spark.sql.schema import parse_schema
+
+
+__all__ = ["Registry", "ModelSpec"]
 
 
 class Registry(ABC):
@@ -95,6 +96,7 @@ class ModelSpec(ABC):
         validate: bool = True,
     ):
         self._spec = spec
+        self._spec["options"] = self._spec.get("options", {})
         if validate:
             self.validate()
 

--- a/python/rikai/spark/sql/codegen/fs.py
+++ b/python/rikai/spark/sql/codegen/fs.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Any, Callable, Dict, IO, Mapping, Optional, Union
+from typing import Any, Dict, IO, Mapping, Optional, Union
 
 import yaml
 from pyspark.sql import SparkSession
@@ -25,11 +25,8 @@ from rikai.spark.sql.codegen.base import (
     Registry,
     udf_from_spec,
 )
-from rikai.spark.sql.exceptions import SpecError
 
 __all__ = ["FileSystemRegistry"]
-
-# YAML-Spec SCHEMA
 
 
 class FileModelSpec(ModelSpec):
@@ -55,9 +52,9 @@ class FileModelSpec(ModelSpec):
         if not isinstance(spec, Mapping):
             spec = yaml.load(spec, Loader=yaml.FullLoader)
         spec.setdefault("options", {})
-        if options:
-            self._options.update(options)
         super().__init__(spec, validate=validate)
+        if options:
+            self.options.update(options)
 
 
 def codegen_from_yaml(

--- a/python/tests/spark/sql/codegen/test_fs.py
+++ b/python/tests/spark/sql/codegen/test_fs.py
@@ -117,6 +117,22 @@ def test_validate_misformed_spec():
         )
 
 
+def test_construct_spec_with_options():
+    spec = FileModelSpec(
+        {
+            "version": "1.0",
+            "name": "with_options",
+            "schema": "int",
+            "model": {
+                "uri": "s3://bucket/to/model.pt",
+                "unspecified_field": True,
+            },
+        },
+        options={"foo": 1, "bar": "2.3"},
+    )
+    assert {"foo": 1, "bar": "2.3"} == spec.options
+
+
 @pytest.mark.timeout(60)
 def test_yaml_model(spark: SparkSession, resnet_spec: str):
     spark.sql("CREATE MODEL resnet_m USING 'file://{}'".format(resnet_spec))


### PR DESCRIPTION
The `FileSystemModelSpec` has not set options before overwriting it. 

This PR fix the order of initializing spec dict with the ModelSpec class.