### PR TITLE
mlflow registry docs and updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ python/rikai/jars/
 .idea/
 .vscode/
 .DS_Store
+
+**/mlruns

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ SELECT id, ML_PREDICT(yolo5, image) FROM my_dataset
 WHERE split = "train" LIMIT 100;
 ```
 
-As of v0.0.5, Rikai is integrated with mlflow. This allows you to automatically pickup the latest
+Rikai can use Mlflow as its model registry. This allows you to automatically pickup the latest
 model version if you're using the mlflow model registry.
 
 ```sql

--- a/README.md
+++ b/README.md
@@ -14,25 +14,25 @@ Join the community:
 # Rikai
 
 Rikai is a [`parquet`](https://parquet.apache.org/) based ML data format built for working with
-unstructured data at scale. Processing large amounts of data for ML is never trivial, but that
-is especially true for images and videos often at the core of deep learning applications. We are
+unstructured data at scale. Processing large amounts of data for ML is never trivial, but is 
+especially true for images and videos often at the core of deep learning applications. We are
 building Rikai with two main goals:
-1. Enable ML engineers/researchers to have a seamless workflow from Feature Engineering (Spark) to Training (PyTorch/Tensorflow),
-   from notebook to production.
+1. Enable ML engineers/researchers to have a seamless workflow from Feature Engineering (Spark) to 
+   Training (PyTorch/Tensorflow), from notebook to production.
 2. Enable advanced analytics capabilities to support much faster active learning, model debugging,
    and monitoring in production pipelines.
 
-Current (v0.0.1) main features:
-1. Native support in Spark and PyTorch for images/videos: reduce ad-hoc type
-   conversions when moving between ETL and training.
-2. Custom functionality for working with images and videos at scale: reduce boilerplate and
-   low-level code currently required to process images, filter/sample videos, etc.
-3. ML-enabled SQL analytics API
+Current (v0.0.5) main features:
+1. Native support in Jupyter, Spark and PyTorch for images, videos and annotations: reduce ad-hoc 
+   type conversions and boilerplate when moving between ETL and training.
+2. Custom functionality for working with images and videos at scale: high-level APIs for 
+   processing, filtering, sampling, and more.
+3. Run ML-models via SQL. Forget Smart Homes, build a Smart Data Warehouse.
 
 Roadmap:
 1. TensorFlow integration
 2. Versioning support built into the dataset
-3. Richer video capabilities (ffmpeg-python integration)
+3. Even richer video capabilities (ffmpeg-python integration)
 4. Declarative annotation API (think vega-lite for annotating images/videos)
 
 ## Example
@@ -103,6 +103,17 @@ SELECT id, ML_PREDICT(yolo5, image) FROM my_dataset
 WHERE split = "train" LIMIT 100;
 ```
 
+As of v0.0.5, Rikai is integrated with mlflow. This allows you to automatically pickup the latest
+model version if you're using the mlflow model registry.
+
+```sql
+CREATE MODEL yolo5
+OPTIONS (min_confidence=0.3, device="gpu", batch_size=32)
+USING "mlflow://yolo5_model/";
+
+SELECT id, ML_PREDICT(yolo5, image) FROM my_dataset
+WHERE split = "train" LIMIT 100;
+```
 
 ## Getting Started
 

--- a/docs/sqlml.rst
+++ b/docs/sqlml.rst
@@ -75,10 +75,10 @@ Rikai extends Spark SQL with four more SQL statements:
         { DESC | DESCRIBE } MODEL model_name;
 
         # Show all models
-        SHOW MODELS
+        SHOW MODELS;
 
         # Delete a model
-        DROP MODEL model_name
+        DROP MODEL model_name;
 
 Rikai uses URL schema to decide which Model Registry to be used to resolve a
 ML Model. Once one ML model is via ``CREATE MODEL``,
@@ -187,11 +187,11 @@ you can always specify schema, pre/post-processing classes in the CREATE MODEL O
         # Create model
         CREATE [OR REPLACE] MODEL model_name
         OPTIONS (
-         'rikai.model.flavor'='pytorch',
-         'rikai.output.schema'='struct<boxes:array<array<float>>, scores:array<float>, labels:array<int>>',
-         'rikai.transforms.pre'='rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.pre_processing',
-         'rikai.transforms.post'='rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.post_processing')
-        USING "mlflow://my_resnet_model";
+         flavor='pytorch',
+         schema='struct<boxes:array<array<float>>, scores:array<float>, labels:array<int>>',
+         pre='rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.pre_processing',
+         post='rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.post_processing')
+        USING 'mlflow://my_resnet_model';
 
     .. warning::
 

--- a/docs/sqlml.rst
+++ b/docs/sqlml.rst
@@ -40,6 +40,10 @@ Before we can use ``Rikai SQL-ML``, we need to configure SparkSession:
             "ai.eto.rikai.sql.model.fs.FileSystemRegistry",
         )
         .config(
+            "rikai.sql.ml.registry.mlflow.impl",
+            "ai.eto.rikai.sql.model.mlflow.MlflowRegistry",
+        )
+        .config(
             "spark.driver.extraJavaOptions",
             "-Dio.netty.tryReflectionSetAccessible=true",
         )
@@ -110,6 +114,90 @@ the content of "s3://bucket/to/spec.yaml" can be:
     .. warning::
 
         YAML-based model spec is still under heavy development.
+
+Mlflow Integration
+------------------
+
+As of v0.0.5, Rikai supports Mlflow Model Registry. Trained models can be logged via Rikai's
+custom model logger OR required attributes can be specified as options in the CREATE MODEL
+statement.
+
+First, the Spark session must be configured to use Rikai's MlflowRegistry as demonstrated above in
+the setup section. Verify that you have the following in your Spark session's configurations:
+
+    .. code-block:: python
+
+        SparkSession
+        .builder
+        .appName("rikai")
+        # other configs
+        .config(
+            "rikai.sql.ml.registry.mlflow.impl",
+            "ai.eto.rikai.sql.model.mlflow.MlflowRegistry",
+        )
+        # other configs
+        .master("local[*]")
+        .getOrCreate()
+
+Rikai comes with a custom model logger to make it easier to add attributes required by Rikai. This
+requires a one-line change from your usual mlflow model logging workflow:
+
+    .. code-block:: python
+
+        import rikai
+        import mlflow
+
+        with mlflow.start_run():
+            # Training loop that results in a model instance
+
+            schema = "struct<boxes:array<array<float>>, scores:array<float>, labels:array<int>>"
+            pre = "rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.pre_processing"
+            post = "rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.post_processing"
+
+            # Rikai's logger adds output_schema, pre_pocessing, and post_processing as additional
+            # arguments and automatically adds the flavor / rikai model spec version
+            rikai.mlflow.pytorch.log_model(
+                trained_model,
+                "path_to_log_artifact_to",
+                schema,
+                pre,
+                post,
+                registered_model_name="my_resnet_model")
+
+Once models are trained, you can add the model to the Rikai model catalog and query it via SparkSQL:
+
+    .. code-block:: sql
+
+        CERATE MODEL model_foo USING 'mlflow://my_resnet_model';
+
+        SELECT id, ML_PREDICT(model_foo, image) FROM df;
+
+If you specify only the mlflow model name as in the above example (i.e., my_resnet_model), Rikai
+will automatically use the latest version. If you have models in different stages as supported by
+mlflow, you can specify the stage like `mlflow://my_resnet_model/production` and Rikai will select
+the latest version whose `current_stage` is "production". Rikai also supports referencing a
+particular version number like `mlflow://my_resnet_model/1` (Rikai distinguishes the stage and
+version by checking whether the path component is a number).
+
+If you have existing models already in mlflow model registry that didn't use Rikai's custom logger,
+you can always specify schema, pre/post-processing classes in the CREATE MODEL OPTIONS:
+
+    .. code-block:: sql
+
+        # Create model
+        CREATE [OR REPLACE] MODEL model_name
+        OPTIONS (
+         'rikai.model.flavor'='pytorch',
+         'rikai.output.schema'='struct<boxes:array<array<float>>, scores:array<float>, labels:array<int>>',
+         'rikai.transforms.pre'='rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.pre_processing',
+         'rikai.transforms.post'='rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.post_processing')
+        USING "mlflow://my_resnet_model";
+
+    .. warning::
+
+        The Rikai model spec and SQL-ML API is still under heavy development so expect breaking changes!
+
+
 
 .. _BigQuery ML: https://cloud.google.com/bigquery-ml/docs
 .. _Redshift ML: https://aws.amazon.com/redshift/features/redshift-ml/

--- a/docs/sqlml.rst
+++ b/docs/sqlml.rst
@@ -180,18 +180,21 @@ particular version number like `mlflow://my_resnet_model/1` (Rikai distinguishes
 version by checking whether the path component is a number).
 
 If you have existing models already in mlflow model registry that didn't use Rikai's custom logger,
-you can always specify schema, pre/post-processing classes in the CREATE MODEL OPTIONS:
+you can always specify schema, pre/post-processing classes as run tags. For example:
 
-    .. code-block:: sql
+    .. code-block:: python
 
-        # Create model
-        CREATE [OR REPLACE] MODEL model_name
-        OPTIONS (
-         flavor='pytorch',
-         schema='struct<boxes:array<array<float>>, scores:array<float>, labels:array<int>>',
-         pre='rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.pre_processing',
-         post='rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.post_processing')
-        USING 'mlflow://my_resnet_model';
+        from mlflow.tracking import MlflowClient
+
+        client = MlflowClient(<tracking_uri>)
+        run_id = client.get_latest_versions("my_resnet_model", stages=['none'])
+        new_tags = {
+         'rikai.model.flavor': 'pytorch',
+         'rikai.output.schema': 'struct<boxes:array<array<float>>, scores:array<float>, labels:array<int>>',
+         'rikai.transforms.pre': 'rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.pre_processing',
+         'rikai.transforms.post': 'rikai.contrib.torch.transforms.fasterrcnn_resnet50_fpn.post_processing'
+         }
+        [client.set_tag(run_id, k, v) for k, v in new_tags.items()]
 
     .. warning::
 

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -117,17 +117,21 @@ class MlflowModelSpec(ModelSpec):
         spec: Dict[str, Any]
         """
         extras = extras or {}
-        spec = {"version": tags.get(CONF_MLFLOW_SPEC_VERSION,
-                                    MlflowLogger._CURRENT_MODEL_SPEC_VERSION),
-                "schema": _get_model_prop(tags, CONF_MLFLOW_OUTPUT_SCHEMA),
-                "model": {
-                    "flavor": _get_model_prop(tags, CONF_MLFLOW_MODEL_FLAVOR),
-                    "uri": uri,
-                },
-                "transforms": {
-                    "pre": tags.get(CONF_MLFLOW_PRE_PROCESSING, None),
-                    "post": tags.get(CONF_MLFLOW_POST_PROCESSING, None)
-                }}
+        spec = {
+            "version": tags.get(
+                CONF_MLFLOW_SPEC_VERSION,
+                MlflowLogger._CURRENT_MODEL_SPEC_VERSION,
+            ),
+            "schema": _get_model_prop(tags, CONF_MLFLOW_OUTPUT_SCHEMA),
+            "model": {
+                "flavor": _get_model_prop(tags, CONF_MLFLOW_MODEL_FLAVOR),
+                "uri": uri,
+            },
+            "transforms": {
+                "pre": tags.get(CONF_MLFLOW_PRE_PROCESSING, None),
+                "post": tags.get(CONF_MLFLOW_POST_PROCESSING, None),
+            },
+        }
 
         # options
         options = dict(params or {})  # for training

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -117,42 +117,17 @@ class MlflowModelSpec(ModelSpec):
         spec: Dict[str, Any]
         """
         extras = extras or {}
-        spec = {
-            "version": _get_model_prop(
-                tags,
-                CONF_MLFLOW_SPEC_VERSION,
-                extras,
-                "spec",
-                MlflowLogger._CURRENT_MODEL_SPEC_VERSION,
-            ),
-            "schema": _get_model_prop(
-                tags, CONF_MLFLOW_OUTPUT_SCHEMA, extras, "schema"
-            ),
-            "model": {
-                "flavor": _get_model_prop(
-                    tags, CONF_MLFLOW_MODEL_FLAVOR, extras, "flavor"
-                ),
-                "uri": uri,
-            },
-        }
-
-        # transforms
-        spec["transforms"] = {
-            "pre": _get_model_prop(
-                tags,
-                CONF_MLFLOW_PRE_PROCESSING,
-                extras,
-                "pre",
-                raise_if_absent=False,
-            ),
-            "post": _get_model_prop(
-                tags,
-                CONF_MLFLOW_POST_PROCESSING,
-                extras,
-                "post",
-                raise_if_absent=False,
-            ),
-        }
+        spec = {"version": tags.get(CONF_MLFLOW_SPEC_VERSION,
+                                    MlflowLogger._CURRENT_MODEL_SPEC_VERSION),
+                "schema": _get_model_prop(tags, CONF_MLFLOW_OUTPUT_SCHEMA),
+                "model": {
+                    "flavor": _get_model_prop(tags, CONF_MLFLOW_MODEL_FLAVOR),
+                    "uri": uri,
+                },
+                "transforms": {
+                    "pre": tags.get(CONF_MLFLOW_PRE_PROCESSING, None),
+                    "post": tags.get(CONF_MLFLOW_POST_PROCESSING, None)
+                }}
 
         # options
         options = dict(params or {})  # for training
@@ -170,12 +145,13 @@ class MlflowModelSpec(ModelSpec):
 def _get_model_prop(
     run_tags: dict,
     conf_name: str,
-    extra_options: dict,
+    extra_options: dict = None,
     option_key: str = None,
     default_value: Any = None,
     raise_if_absent: bool = True,
 ) -> Any:
-    option_key = conf_name if not option_key else option_key
+    extra_options = extra_options or {}
+    option_key = option_key or conf_name
     value = run_tags.get(
         conf_name, extra_options.get(option_key, default_value)
     )

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -119,12 +119,15 @@ class MlflowModelSpec(ModelSpec):
         extras = extras or {}
         spec = {
             "version": _get_model_prop(
-                tags, CONF_MLFLOW_SPEC_VERSION,
-                extras, "spec",
+                tags,
+                CONF_MLFLOW_SPEC_VERSION,
+                extras,
+                "spec",
                 MlflowLogger._CURRENT_MODEL_SPEC_VERSION,
             ),
-            "schema": _get_model_prop(tags, CONF_MLFLOW_OUTPUT_SCHEMA,
-                                      extras, "schema"),
+            "schema": _get_model_prop(
+                tags, CONF_MLFLOW_OUTPUT_SCHEMA, extras, "schema"
+            ),
             "model": {
                 "flavor": _get_model_prop(
                     tags, CONF_MLFLOW_MODEL_FLAVOR, extras, "flavor"
@@ -136,12 +139,18 @@ class MlflowModelSpec(ModelSpec):
         # transforms
         spec["transforms"] = {
             "pre": _get_model_prop(
-                tags, CONF_MLFLOW_PRE_PROCESSING, extras, "pre",
-                raise_if_absent=False
+                tags,
+                CONF_MLFLOW_PRE_PROCESSING,
+                extras,
+                "pre",
+                raise_if_absent=False,
             ),
             "post": _get_model_prop(
-                tags, CONF_MLFLOW_POST_PROCESSING, extras, "post",
-                raise_if_absent=False
+                tags,
+                CONF_MLFLOW_POST_PROCESSING,
+                extras,
+                "post",
+                raise_if_absent=False,
             ),
         }
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -42,14 +42,6 @@ def spark(tmp_path_factory) -> SparkSession:
             "ai.eto.rikai.sql.model.testing.TestRegistry",
         )
         .config(
-            "rikai.sql.ml.registry.file.impl",
-            "ai.eto.rikai.sql.model.fs.FileSystemRegistry",
-        )
-        .config(
-            "rikai.sql.ml.registry.mlflow.impl",
-            "ai.eto.rikai.sql.model.mlflow.MlflowRegistry",
-        )
-        .config(
             "spark.driver.extraJavaOptions",
             "-Dio.netty.tryReflectionSetAccessible=true",
         )

--- a/python/tests/spark/sql/codegen/test_mlflow_registry.py
+++ b/python/tests/spark/sql/codegen/test_mlflow_registry.py
@@ -62,8 +62,9 @@ def mlflow_client(
 
     # vanilla mlflow
     with mlflow.start_run():
-        mlflow.pytorch.log_model(model, artifact_path,
-                                 registered_model_name="vanilla-mlflow")
+        mlflow.pytorch.log_model(
+            model, artifact_path, registered_model_name="vanilla-mlflow"
+        )
     spark.conf.set("rikai.sql.ml.registry.mlflow.tracking_uri", tracking_uri)
     return mlflow.tracking.MlflowClient(tracking_uri)
 
@@ -123,7 +124,9 @@ def test_mlflow_model_from_model_version(spark: SparkSession, mlflow_client):
 
 
 @pytest.mark.timeout(60)
-def test_mlflow_model_without_custom_logger(spark: SparkSession, mlflow_client):
+def test_mlflow_model_without_custom_logger(
+    spark: SparkSession, mlflow_client
+):
     # peg to a particular version of a model
     schema = (
         "struct<boxes:array<array<float>>,"
@@ -138,11 +141,11 @@ def test_mlflow_model_without_custom_logger(spark: SparkSession, mlflow_client):
         "fasterrcnn_resnet50_fpn.post_processing"
     )
 
-    sql = ('CREATE MODEL vanilla_ice ' 
-           'OPTIONS (flavor="pytorch",schema="{}",pre="{}",post="{}") '
-           'USING "mlflow://vanilla-mlflow/1"').format(
-        schema, pre_processing, post_processing)
+    sql = (
+        "CREATE MODEL vanilla_ice "
+        'OPTIONS (flavor="pytorch",schema="{}",pre="{}",post="{}") '
+        'USING "mlflow://vanilla-mlflow/1"'
+    ).format(schema, pre_processing, post_processing)
 
     spark.sql(sql)
     check_ml_predict(spark, "vanilla_ice")
-

--- a/python/tests/spark/sql/codegen/test_mlflow_registry.py
+++ b/python/tests/spark/sql/codegen/test_mlflow_registry.py
@@ -139,13 +139,10 @@ def test_mlflow_model_without_custom_logger(spark: SparkSession, mlflow_client):
     )
 
     sql = ('CREATE MODEL vanilla_ice ' 
-           'OPTIONS ('
-           '"rikai.model.flavor"="pytorch",'
-           '"rikai.output.schema"="{}",'
-           '"rikai.transforms.pre"="{}",'
-           '"rikai.transforms.post"="{}") '
-           'USING "mlflow://vanilla-mlflow/1"').format(schema, pre_processing,
-                                                       post_processing)
+           'OPTIONS (flavor="pytorch",schema="{}",pre="{}",post="{}") '
+           'USING "mlflow://vanilla-mlflow/1"').format(
+        schema, pre_processing, post_processing)
+
     spark.sql(sql)
     check_ml_predict(spark, "vanilla_ice")
 

--- a/python/tests/spark/sql/codegen/test_mlflow_registry.py
+++ b/python/tests/spark/sql/codegen/test_mlflow_registry.py
@@ -65,12 +65,14 @@ def mlflow_client(
         mlflow.pytorch.log_model(
             model, artifact_path, registered_model_name="vanilla-mlflow"
         )
-        mlflow.set_tags({
-            'rikai.model.flavor': 'pytorch',
-            'rikai.output.schema': schema,
-            'rikai.transforms.pre': pre_processing,
-            'rikai.transforms.post': post_processing
-        })
+        mlflow.set_tags(
+            {
+                "rikai.model.flavor": "pytorch",
+                "rikai.output.schema": schema,
+                "rikai.transforms.pre": pre_processing,
+                "rikai.transforms.post": post_processing,
+            }
+        )
     spark.conf.set("rikai.sql.ml.registry.mlflow.tracking_uri", tracking_uri)
     return mlflow.tracking.MlflowClient(tracking_uri)
 

--- a/src/main/scala/ai/eto/rikai/sql/model/Registry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/Registry.scala
@@ -52,6 +52,11 @@ object Registry {
   val REGISTRY_IMPL_PREFIX = "rikai.sql.ml.registry."
   val REGISTRY_IMPL_SUFFIX = ".impl"
 
+  val DEFAULT_REGISTRIES = Map(
+    "rikai.sql.ml.registry.file.impl" -> "ai.eto.rikai.sql.model.fs.FileSystemRegistry",
+    "rikai.sql.ml.registry.mlflow.impl" -> "ai.eto.rikai.sql.model.mlflow.MlflowRegistry"
+  )
+
   /** Mapping from Model URI schema to the registry. */
   private var registryMap: Map[String, Registry] = Map.empty
 
@@ -71,7 +76,8 @@ object Registry {
     * @param conf a mapping of (key, value) pairs
     */
   def registerAll(conf: Map[String, String]): Unit = {
-    for ((key, value) <- conf) {
+    // defaults
+    for ((key, value) <- DEFAULT_REGISTRIES ++ conf) {
       if (
         key.startsWith(REGISTRY_IMPL_PREFIX) &&
         key.endsWith(REGISTRY_IMPL_SUFFIX)
@@ -95,7 +101,6 @@ object Registry {
             .asInstanceOf[Registry])
         logger.debug(s"Model Registry ${schema} registered to: ${value}")
       }
-
     }
   }
 

--- a/src/main/scala/ai/eto/rikai/sql/model/Registry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/Registry.scala
@@ -31,13 +31,18 @@ trait Registry {
     * @param uri is the model registry URI.
     * @param name is an optional model name. If provided,
     *             will create the [[Model]] with this name.
+    * @param options is an optional model options Map.
     *
     * @throws ModelNotFoundException if the model does not exist on the registry.
     *
     * @return [[Model]] if found.
     */
   @throws[ModelNotFoundException]
-  def resolve(uri: String, name: Option[String] = None): Model
+  def resolve(
+      uri: String,
+      name: Option[String] = None,
+      options: Option[Map[String, String]]
+  ): Model
 }
 
 object Registry {
@@ -102,6 +107,7 @@ object Registry {
     *
     * @param uri the model registry URI
     * @param name optionally, model name
+    * @param options optionally, extra model options
     *
     * @throws ModelNotFoundException if the model not found on the registry.
     * @throws ModelResolveException can not resolve the model due to system issues.
@@ -110,11 +116,16 @@ object Registry {
     */
   @throws[ModelResolveException]
   @throws[ModelNotFoundException]
-  def resolve(uri: String, name: Option[String] = None): Model = {
+  def resolve(
+      uri: String,
+      name: Option[String] = None,
+      options: Option[Map[String, String]] = None
+  ): Model = {
     val parsedUri = new URI(uri)
     val schema: String = parsedUri.getScheme
     registryMap.get(schema) match {
-      case Some(registry) => registry.resolve(uri, name = name)
+      case Some(registry) =>
+        registry.resolve(uri, name = name, options = options)
       case None =>
         throw new ModelResolveException(
           s"Model registry schema '${schema}' is not supported"

--- a/src/main/scala/ai/eto/rikai/sql/model/fs/FileSystemRegistry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/fs/FileSystemRegistry.scala
@@ -41,8 +41,12 @@ class FileSystemRegistry(val conf: Map[String, String])
     * @return [[Model]] if found.
     */
   @throws[ModelNotFoundException]
-  override def resolve(uri: String, name: Option[String]): Model = {
+  override def resolve(
+      uri: String,
+      name: Option[String],
+      options: Option[Map[String, String]]
+  ): Model = {
     logger.info(s"Resolving ML model from ${uri}")
-    Python.resolve(pyClass, uri, name, Map.empty)
+    Python.resolve(pyClass, uri, name, options.getOrElse(Map.empty))
   }
 }

--- a/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowRegistry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowRegistry.scala
@@ -42,8 +42,12 @@ class MlflowRegistry(val conf: Map[String, String])
     * @return [[Model]] if found.
     */
   @throws[ModelNotFoundException]
-  override def resolve(uri: String, name: Option[String]): Model = {
+  override def resolve(
+      uri: String,
+      name: Option[String],
+      options: Option[Map[String, String]]
+  ): Model = {
     logger.info(s"Resolving ML model from ${uri}")
-    Python.resolve(pyClass, uri, name, Map.empty)
+    Python.resolve(pyClass, uri, name, options.getOrElse(Map.empty))
   }
 }

--- a/src/main/scala/ai/eto/rikai/sql/model/testing/TestRegistry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/testing/TestRegistry.scala
@@ -43,7 +43,11 @@ class TestRegistry(conf: Map[String, String]) extends Registry {
     * @return [[Model]] if found, ``None`` otherwise.
     */
   @throws[ModelNotFoundException]
-  override def resolve(uri: String, name: Option[String] = None): Model = {
+  override def resolve(
+      uri: String,
+      name: Option[String] = None,
+      options: Option[Map[String, String]] = None
+  ): Model = {
     val parsed = URI.create(uri)
     parsed.getScheme match {
       case this.schema => {

--- a/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
@@ -38,9 +38,9 @@ case class CreateModelCommand(
     if (catalog(spark).modelExists(name)) {
       throw new ModelAlreadyExistException(s"Model (${name}) already exists")
     }
-
+    logger.error(options)
     val model = uri match {
-      case Some(u) => Registry.resolve(u, Some(name))
+      case Some(u) => Registry.resolve(u, Some(name), Some(options))
       case None =>
         throw new ModelResolveException(
           "Must provide URI to CREATE MODEL (for now)"

--- a/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
@@ -38,7 +38,6 @@ case class CreateModelCommand(
     if (catalog(spark).modelExists(name)) {
       throw new ModelAlreadyExistException(s"Model (${name}) already exists")
     }
-    logger.error(options)
     val model = uri match {
       case Some(u) => Registry.resolve(u, Some(name), Some(options))
       case None =>


### PR DESCRIPTION
1. Updated README and sqlml docs for mlflow registry integration
2. Add unit test for CREATE MODEL on plain vanilla mlflow model (without the custom logger)
3. To make #2 work, pass in the options dict to model resolve

I think it might make sense to add a "MODELPROPERTIES" or similar clause so that we can separate the resolve time options vs run time options.