### PR TITLE
Add support for negative numbers

### DIFF
--- a/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
@@ -88,17 +88,17 @@ optionKey
 
 optionValue
     : INTEGER_VALUE
-    | DECIMAL_VALUE
+    | FLOATING_VALUE
     | booleanValue
     | STRING
     ;
 
 INTEGER_VALUE
-    : DIGIT+
+    : MINUS? DIGIT+
     ;
 
-DECIMAL_VALUE
-    : DECIMAL_DIGITS
+FLOATING_VALUE
+    : MINUS? DECIMAL_DIGITS
     ;
 
 booleanValue
@@ -135,4 +135,8 @@ WS  : [ \r\n\t]+ -> channel(HIDDEN)
 
 UNRECOGNIZED
     : .
+    ;
+
+MINUS
+    : '-'
     ;

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtAstBuilder.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtAstBuilder.scala
@@ -84,8 +84,8 @@ private[parser] class RikaiExtAstBuilder
       else {
         "false"
       }
-    } else if (ctx.value.DECIMAL_VALUE() != null) {
-      ctx.value.DECIMAL_VALUE.getSymbol.getText
+    } else if (ctx.value.FLOATING_VALUE() != null) {
+      ctx.value.FLOATING_VALUE.getSymbol.getText
     } else if (ctx.value.INTEGER_VALUE() != null) {
       ctx.value.INTEGER_VALUE.getSymbol.getText
     } else {

--- a/src/test/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommandTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommandTest.scala
@@ -39,7 +39,7 @@ class CreateModelCommandTest extends AnyFunSuite with SparkTestSession {
     spark
       .sql(
         "CREATE MODEL qualified_opt OPTIONS (" +
-          "rikai.foo.bar=1.23, foo='bar', num=1.23, flag=True) " +
+          "rikai.foo.bar=1.23, foo='bar', num=-1.23, flag=True) " +
           "USING 'test://foo/options'"
       )
       .count()
@@ -47,7 +47,7 @@ class CreateModelCommandTest extends AnyFunSuite with SparkTestSession {
     assert(
       model.options == Seq(
         "foo" -> "bar",
-        "num" -> "1.23",
+        "num" -> "-1.23",
         "flag" -> "true",
         "rikai.foo.bar" -> "1.23"
       ).toMap


### PR DESCRIPTION
Change DECIMAL_VALUE -> FLOATING_VALUE. We should use DECIMAL to indicate number
base if we need to support binary/hex/oct numbers in the future.