### PR TITLE
Parse RETURNS schema in CREATE MODEL

### DIFF
--- a/python/tests/spark/test_functions.py
+++ b/python/tests/spark/test_functions.py
@@ -17,13 +17,12 @@
 import os
 from io import BytesIO
 from pathlib import Path
-import pytest
 
 import numpy as np
 import pandas as pd
 import pandas.testing as pdt
+import pytest
 from PIL import Image as PILImage
-
 from pyspark.sql import Row, SparkSession
 from pyspark.sql.functions import col, concat, lit
 
@@ -33,10 +32,10 @@ from rikai.spark.functions import (
     area,
     box2d,
     box2d_from_center,
-    to_image,
     image_copy,
     numpy_to_image,
     spectrogram_image,
+    to_image,
     video_to_images,
 )
 from rikai.types import Box2d, Image, Segment, VideoStream, YouTubeVideo

--- a/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
@@ -23,6 +23,7 @@ statement
     : CREATE (OR REPLACE)? MODEL model=qualifiedName
       (FLAVOR flavor=identifier)?
       (OPTIONS optionList)?
+      (RETURNS datatype=dataType)?
       (USING uri=STRING)	                        # createModel
     | (DESC | DESCRIBE) MODEL model=qualifiedName   # describeModel
     | SHOW MODELS                                   # showModels
@@ -46,6 +47,7 @@ nonReserved
     : CREATE | DESC | DESCRIBE | MODEL | MODELS | OPTIONS | REPLACE
     ;
 
+ARRAY: 'ARRAY';
 AS: 'AS';
 CREATE: 'CREATE';
 DESC : 'DESC';
@@ -59,7 +61,9 @@ MODELS: 'MODELS';
 OPTIONS: 'OPTIONS';
 OR: 'OR';
 REPLACE: 'REPLACE';
+RETURNS: 'RETURNS';
 SHOW: 'SHOW';
+STRUCT: 'STRUCT';
 TRUE: 'TRUE';
 USING: 'USING';
 
@@ -93,6 +97,24 @@ optionValue
     | FLOATING_VALUE
     | booleanValue
     | STRING
+    ;
+
+struct
+    : STRUCT '<' field (',' field)* '>'  # structType
+    ;
+
+array
+    : ARRAY '<' dataType '>'  # arrayType
+    ;
+
+dataType
+    : struct # nestedStructType
+    | array  # nestedArrayType
+    | identifier  # plainFieldType
+    ;
+
+field
+    : name=identifier ':' dataType   # structField
     ;
 
 INTEGER_VALUE

--- a/src/main/scala/ai/eto/rikai/sql/model/ModelSpec.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/ModelSpec.scala
@@ -25,12 +25,15 @@ class ModelSpec(
     val name: Option[String],
     val uri: String,
     val flavor: Option[String] = None,
+    val schema: Option[String] = None,
     val options: Option[Map[String, String]] = None
 ) {
 
   def getName: String = name.getOrElse("")
 
   def getUri: String = uri
+
+  def getSchema: String = schema.getOrElse("")
 
   def getOptions: java.util.Map[String, String] =
     mapAsJavaMap(options.getOrElse(Map.empty))

--- a/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.{Row, SparkSession}
 case class CreateModelCommand(
     name: String,
     flavor: Option[String],
+    returns: Option[String],
     uri: Option[String],
     table: Option[TableIdentifier],
     replace: Boolean,

--- a/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
@@ -47,6 +47,7 @@ case class CreateModelCommand(
           name = Some(name),
           uri = u,
           flavor = flavor,
+          schema = returns,
           options = Some(options)
         )
         Registry.resolve(spec)

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtSparkSQLParser.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtSparkSQLParser.scala
@@ -43,9 +43,15 @@ import org.apache.spark.sql.{AnalysisException, SparkSession}
   */
 private[spark] class RikaiExtSqlParser(
     val session: SparkSession,
-    val delegate: ParserInterface
+    val delegate: ParserInterface,
+    val testing: Boolean = false
 ) extends ParserInterface
     with Logging {
+
+  /** Used for test only */
+  def this() {
+    this(null, null, true)
+  }
 
   private val builder = new RikaiExtAstBuilder()
 
@@ -54,7 +60,7 @@ private[spark] class RikaiExtSqlParser(
   }
 
   override def parsePlan(sqlText: String): LogicalPlan = {
-    if (!registyInitialized) {
+    if (!testing && !registyInitialized) {
       // not suppose to be here?
     }
     parse(sqlText) { parser =>

--- a/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiExtAstSqlParserTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiExtAstSqlParserTest.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Rikai authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.eto.rikai.sql.spark.parser
+
+import ai.eto.rikai.sql.spark.execution.CreateModelCommand
+import org.scalatest.funsuite.AnyFunSuite
+
+class RikaiExtAstSqlParserTest extends AnyFunSuite {
+
+  val parser = new RikaiExtSqlParser()
+
+  test("parse returns datatype") {
+    val cmd = parser.parsePlan(
+      "CREATE MODEL foo RETURNS STRUCT<foo:int, bar:ARRAY<STRING>> USING 'abc'"
+    )
+    assert(cmd.isInstanceOf[CreateModelCommand])
+    val create = cmd.asInstanceOf[CreateModelCommand]
+    assert(create.name == "foo")
+    assert(create.uri.contains("abc"))
+    assert(create.returns.contains("STRUCT<foo:int, bar:ARRAY<STRING>>"))
+  }
+
+  test("parse returns UDTs") {
+    val cmd = parser.parsePlan(
+      "CREATE MODEL udts RETURNS STRUCT<foo:int, bar:ARRAY<Box2d>> USING 'gs://udt/bucket'"
+    )
+    assert(cmd.isInstanceOf[CreateModelCommand])
+    val create = cmd.asInstanceOf[CreateModelCommand]
+    assert(create.name == "udts")
+    assert(create.uri.contains("gs://udt/bucket"))
+    assert(create.returns.contains("STRUCT<foo:int, bar:ARRAY<Box2d>>"))
+  }
+}


### PR DESCRIPTION
Support `RETURNS dataType` in CREATE MODEL