### PR TITLE
A few minor build fixes

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,6 +44,8 @@ jobs:
       working-directory: python
       run: |
         pytest -v --durations=10 --ignore=tests/parquet/internal
+      env:
+        SPARK_LOCAL_IP: "127.0.0.1"
   mac-build:
     runs-on: macos-latest
     timeout-minutes: 10

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -26,5 +26,7 @@ jobs:
       run: sbt scalafmtCheckAll
     - name: Run Scala tests
       run: sbt test
+      env:
+        SPARK_LOCAL_IP: "127.0.0.1"
     - name: Build Scala Jar
       run: sbt package

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+import java.io.File
+import scala.reflect.io.Directory
+
 scalaVersion := "2.12.11"
 name := "rikai"
 
@@ -94,3 +97,19 @@ Compile / doc / scalacOptions ++= Seq(
   "-skip-packages",
   "ai.eto.rikai.sql.spark.parser"
 )
+
+publishLocal := {
+  val ivyHome = ivyPaths.value.ivyHome.get.getCanonicalPath
+  val cachePath =
+    s"${ivyHome}/cache/${organization.value}/${name.value}_${scalaVersion.value.split('.').slice(0, 2).mkString(".")}"
+  val cache = new Directory(new File(cachePath))
+  if (cache.exists) {
+    println("Rikai found in local cache. Removing...")
+    assert(
+      cache.deleteRecursively(),
+      s"Could not delete Rikai cache ${cachePath}"
+    )
+    println(s"Local Rikai cache removed (${cachePath})")
+  }
+  publishLocal.value
+}

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -32,7 +32,7 @@ def spark(tmp_path_factory) -> SparkSession:
     version = get_default_jar_version(use_snapshot=True)
     session = (
         SparkSession.builder.appName("spark-test")
-        .config("spark.driver.host", "127.0.0.1")
+        .config("spark.port.maxRetries", 128)
         .config("spark.jars.packages", f"ai.eto:rikai_2.12:{version}")
         .config(
             "spark.sql.extensions",

--- a/src/test/scala/ai/eto/rikai/SparkTestSession.scala
+++ b/src/test/scala/ai/eto/rikai/SparkTestSession.scala
@@ -41,7 +41,7 @@ trait SparkTestSession extends BeforeAndAfterEach {
       Registry.REGISTRY_IMPL_PREFIX + "test.impl",
       "ai.eto.rikai.sql.model.testing.TestRegistry"
     )
-    .config("spark.driver.host", "127.0.0.1")
+    .config("spark.port.maxRetries", 128)
     .master("local[*]")
     .getOrCreate
 


### PR DESCRIPTION
1. Set SPARK_LOCAL_IP and increase spark.port.maxRetries to hopefully fix test flakiness for Spark
2. Automatically delete the rikai ivy cache when publishLocal.

publishLocal sends the jar to ivy local repository. When we run tests which refers to
the rikai jar as a spark package, it loads the local jar and caches it. This then makes it
so that subsequent publishLocal is shadowed by the cached jar unless it is manually removed.
Instead we override publishLocal task to first delete the ivyHome/cache/ai.eto/rikai_2.12 directory