### PR TITLE
Run the sbt tests in a child process so Spark can shutdown properly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,8 @@ scalacOptions ++= Seq(
   "-Xlint:unused"
 )
 
-Test / parallelExecution := false
+parallelExecution in Test := false
+fork in Test := true
 
 antlr4PackageName in Antlr4 := Some("ai.eto.rikai.sql.spark.parser")
 antlr4GenVisitor in Antlr4 := true


### PR DESCRIPTION
gets rid of the ShutdownManager warnings after tests finish