### PR TITLE
[release] Use separate workflow to create GH release

### DIFF
--- a/.github/workflows/bump-version-release.yml
+++ b/.github/workflows/bump-version-release.yml
@@ -18,10 +18,10 @@ jobs:
       run: |
         git config user.name 'Rikai Release'
         git config user.email 'rikai-dev@eto.ai'
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.7
     - name: Pip install
       working-directory: python
       run: |

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,0 +1,42 @@
+name: Make GH release from tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+    - name: Check out master
+      uses: actions/checkout@v2
+      with:
+        ref: master
+        persist-credentials: false
+        fetch-depth: 0
+    - name: Set git configs for bumpversion
+      run: |
+        git config user.name 'Rikai Release'
+        git config user.email 'rikai-dev@eto.ai'
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Pip install
+      working-directory: python
+      run: |
+        sudo apt-get -y -qq install libsnappy-dev ffmpeg
+        python -m pip install -e .[all,dev]
+    - name: Make new github release
+      uses: ncipollo/release-action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Bump patch back to dev build
+      run: make patch
+    - name: Push changes
+      uses: changhiskhan/github-push-action@master
+      with:
+        github_token: ${{ secrets.RELEASE_TOKEN }}
+        branch: master

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -20,10 +20,10 @@ jobs:
       run: |
         git config user.name 'Rikai Release'
         git config user.email 'rikai-dev@eto.ai'
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.7
     - name: Pip install
       working-directory: python
       run: |


### PR DESCRIPTION
Patch release process:

1. Manually trigger bump-version-release.yml workflow. This runs
   all checks, does bumpversion and creates new tag.
2. Once the tag has been created, make-release.yml will automatically
   run (on tag push). This creates a GH release of the tag and also
   puts master back to dev build.
3. Once the GH release is created, python-publish.yml and
   scala-publish.yml will trigger to build and upload the artifacts to
   pypi and sonatype. It'll take a few hours for sonatype repo to get
   sync'd in maven central.