### PR TITLE
Support pandas < 0.25 in rikai.conf

### DIFF
--- a/python/rikai/conf.py
+++ b/python/rikai/conf.py
@@ -22,6 +22,7 @@ import os
 import tempfile
 
 import pandas as pd
+
 try:
     from pandas._config.config import (
         get_option,

--- a/python/rikai/conf.py
+++ b/python/rikai/conf.py
@@ -22,12 +22,20 @@ import os
 import tempfile
 
 import pandas as pd
-from pandas._config.config import (
-    get_option,
-    register_option,
-    reset_option,
-    set_option,
-)
+try:
+    from pandas._config.config import (
+        get_option,
+        register_option,
+        reset_option,
+        set_option,
+    )
+except ModuleNotFoundError:
+    from pandas.core.config import (
+        get_option,
+        register_option,
+        reset_option,
+        set_option,
+    )
 
 options = pd.options
 


### PR DESCRIPTION
`pandas.core.config` objects were moved to `pandas._config.config` in Pandas 0.25. Add a try-import to support earlier versions of Pandas.