### PR TITLE
Add udf to retrieve video metadata using ffprobe

### DIFF
--- a/python/rikai/spark/functions/vision.py
+++ b/python/rikai/spark/functions/vision.py
@@ -313,7 +313,14 @@ def video_metadata(video: Union[str, VideoStream]) -> dict:
 
 
 def _probe(video):
-    import ffmpeg
+    try:
+        import ffmpeg
+    except ImportError:
+        raise ValueError(
+            "Couldn't import ffmpeg. Please make sure to "
+            "`pip install ffmpeg-python` explicitly or install "
+            "the correct extras like `pip install rikai[video]`"
+        )
 
     uri = video.uri if isinstance(video, VideoStream) else video
     try:
@@ -395,7 +402,7 @@ def spectrogram_image(
         raise ValueError(
             "Couldn't import ffmpeg. Please make sure to "
             "`pip install ffmpeg-python` explicitly or install "
-            "the correct extras like `pip install rikai[all]`"
+            "the correct extras like `pip install rikai[video]`"
         )
     assert isinstance(
         video, (YouTubeVideo, VideoStream)

--- a/python/rikai/spark/functions/vision.py
+++ b/python/rikai/spark/functions/vision.py
@@ -274,7 +274,7 @@ def video_metadata(video: Union[str, VideoStream]) -> dict:
     ```
     import rikai.spark.functions as RF
     (spark.createDataFrame([(VideoStream(<uri>),)], ['video'])
-          .withColumn('meta', RF.video_metadata('video').alias('meta'))
+          .withColumn('meta', RF.video_metadata('video'))
           .select('meta.data.frame_rate'))
     ```
     """

--- a/python/rikai/spark/functions/vision.py
+++ b/python/rikai/spark/functions/vision.py
@@ -215,27 +215,29 @@ def video_to_images(
     ]
 
 
-video_metadata_schema = StructType([
-    StructField("width", IntegerType(), True),
-    StructField("height", IntegerType(), True),
-    StructField("num_frames", IntegerType(), True),
-    StructField("duration", FloatType(), True),
-    StructField("bit_rate", IntegerType(), True),
-    StructField("frame_rate", IntegerType(), True),
-    StructField("codec", StringType(), True),
-    StructField("size", IntegerType(), True),
-    StructField(
-        "_errors",
-        StructType(
-            [
-                StructField("message", StringType(), True),
-                StructField("stderr", StringType(), True),
-                StructField("probe", StringType(), True),
-            ]
+video_metadata_schema = StructType(
+    [
+        StructField("width", IntegerType(), True),
+        StructField("height", IntegerType(), True),
+        StructField("num_frames", IntegerType(), True),
+        StructField("duration", FloatType(), True),
+        StructField("bit_rate", IntegerType(), True),
+        StructField("frame_rate", IntegerType(), True),
+        StructField("codec", StringType(), True),
+        StructField("size", IntegerType(), True),
+        StructField(
+            "_errors",
+            StructType(
+                [
+                    StructField("message", StringType(), True),
+                    StructField("stderr", StringType(), True),
+                    StructField("probe", StringType(), True),
+                ]
+            ),
+            True,
         ),
-        True,
-    )
-])
+    ]
+)
 
 
 @udf(returnType=video_metadata_schema)
@@ -291,17 +293,15 @@ def video_metadata(video: Union[str, VideoStream]) -> dict:
 
     try:
         return {
-                "width": _int_or_none(video_stream, "width"),
-                "height": _int_or_none(video_stream, "height"),
-                "num_frames": _int_or_none(video_stream, "nb_frames"),
-                "frame_rate": _fps_or_none(video_stream),
-                "duration": _float_or_none(video_stream, "duration"),
-                "bit_rate": _int_or_none(video_stream, "bit_rate"),
-                "codec": video_stream.get("codec_name", None),
-                "size": _int_or_none(
-                    probe_result.get("format", {}), "size"
-                ),
-            }
+            "width": _int_or_none(video_stream, "width"),
+            "height": _int_or_none(video_stream, "height"),
+            "num_frames": _int_or_none(video_stream, "nb_frames"),
+            "frame_rate": _fps_or_none(video_stream),
+            "duration": _float_or_none(video_stream, "duration"),
+            "bit_rate": _int_or_none(video_stream, "bit_rate"),
+            "codec": video_stream.get("codec_name", None),
+            "size": _int_or_none(probe_result.get("format", {}), "size"),
+        }
     except Exception as e:
         return _error(str(e))
 

--- a/python/rikai/types/video.py
+++ b/python/rikai/types/video.py
@@ -131,7 +131,7 @@ def getworst(v_pafy, preftype="any", ftypestrict=True, vidonly=False):
         return None
 
     def _sortkey(x, key3d=0, keyres=0, keyftype=0):
-        """ sort function for max(). """
+        """sort function for max()."""
         key3d = "3D" not in x.resolution
         keyres = int(x.resolution.split("x")[0])
         keyftype = preftype == x.extension

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,6 +28,7 @@ jupyter = ["matplotlib", "jupyterlab"]
 gcp = ["gcsfs"]
 docs = ["sphinx"]
 youtube = ["pafy", "youtube_dl"]
+video = ["ffmpeg-python"]
 mlflow = ["mlflow>=1.15"]
 all = torch + jupyter + gcp + docs + youtube + mlflow
 
@@ -46,7 +47,6 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "antlr4-python3-runtime",
-        "ffmpeg-python",
         "ipython",
         "jsonschema",
         "numpy",
@@ -67,6 +67,7 @@ setup(
         "jupyter": jupyter,
         "mlflow": mlflow,
         "pytorch": torch,
+        "video": video,
         "youtube": youtube,
     },
     classifiers=[

--- a/python/setup.py
+++ b/python/setup.py
@@ -27,7 +27,7 @@ torch = ["torch>=1.4.0", "torchvision"]
 jupyter = ["matplotlib", "jupyterlab"]
 gcp = ["gcsfs"]
 docs = ["sphinx"]
-youtube = ["pafy", "youtube_dl", "ffmpeg-python"]
+youtube = ["pafy", "youtube_dl"]
 mlflow = ["mlflow>=1.15"]
 all = torch + jupyter + gcp + docs + youtube + mlflow
 
@@ -46,6 +46,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "antlr4-python3-runtime",
+        "ffmpeg-python",
         "ipython",
         "jsonschema",
         "numpy",

--- a/python/setup.py
+++ b/python/setup.py
@@ -27,10 +27,10 @@ torch = ["torch>=1.4.0", "torchvision"]
 jupyter = ["matplotlib", "jupyterlab"]
 gcp = ["gcsfs"]
 docs = ["sphinx"]
-youtube = ["pafy", "youtube_dl"]
 video = ["ffmpeg-python"]
+youtube = ["pafy", "youtube_dl"]
 mlflow = ["mlflow>=1.15"]
-all = torch + jupyter + gcp + docs + youtube + mlflow
+all = torch + jupyter + gcp + docs + video + youtube + mlflow
 
 
 setup(

--- a/python/tests/spark/test_functions.py
+++ b/python/tests/spark/test_functions.py
@@ -276,11 +276,9 @@ def test_video_metadata(spark: SparkSession, asset_path: Path):
         "frame_rate": 30,
         "codec": "h264",
         "size": 736613,
-        "_errors": None
+        "_errors": None,
     }
-    pdt.assert_series_equal(
-        pd.Series(result), pd.Series(expected)
-    )
+    pdt.assert_series_equal(pd.Series(result), pd.Series(expected))
 
     video = "bad_uri"
     result = (

--- a/python/tests/spark/test_functions.py
+++ b/python/tests/spark/test_functions.py
@@ -276,11 +276,11 @@ def test_video_metadata(spark: SparkSession, asset_path: Path):
         "frame_rate": 30,
         "codec": "h264",
         "size": 736613,
+        "_errors": None
     }
     pdt.assert_series_equal(
-        pd.Series(result["data"].asDict()), pd.Series(expected)
+        pd.Series(result), pd.Series(expected)
     )
-    assert result["error"] is None
 
     video = "bad_uri"
     result = (
@@ -289,7 +289,6 @@ def test_video_metadata(spark: SparkSession, asset_path: Path):
         .first()["meta"]
         .asDict()
     )
-    assert result["data"] is None
-    err = result["error"].asDict()
+    err = result["_errors"].asDict()
     assert err["message"].startswith("ffprobe error")
     assert "bad_uri: No such file or directory" in err["stderr"]


### PR DESCRIPTION
@smellslikeml had a good prototype for getting the frame rate out using
ffmpeg's ffprobe functionality. This commit generalizes that and makes
it more robust in a distributed context (e.g., error handling).
In addition to the frame rate we're also returning a number of other
metadata attributes like width, height, duration, size, etc.