### PR TITLE
pin antlr4Version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,9 @@ fork in Test := true
 
 antlr4PackageName in Antlr4 := Some("ai.eto.rikai.sql.spark.parser")
 antlr4GenVisitor in Antlr4 := true
+// explicitly pin antlr4Version to avoid potential bugs
+// antlr4Version should be the same with the one bundled with Apache Spark
+antlr4Version in Antlr4 := "4.8-1"
 
 enablePlugins(Antlr4Plugin)
 


### PR DESCRIPTION
This pr does not solve existing bugs, it prevents future potential bugs.

If the ANTRL version does not match, the following warnings are printed:

> ANTLR Tool version 4.7 used for code generation does not match the current runtime version 4.8ANTLR Tool version 4.7 used for code generation does not match the current runtime version 4.8