### PR TITLE
Fix: CREATE MODEL option can not take integer value

### DIFF
--- a/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
@@ -82,7 +82,7 @@ STRING
     ;
 
 IDENTIFIER
-    : (LETTER | DIGIT | '_')+
+    : NONDIGIT (LETTER | DIGIT | '_')*
     ;
 
 BACKQUOTED_IDENTIFIER
@@ -151,6 +151,10 @@ fragment EXPONENT
 
 fragment DIGIT
     : [0-9]
+    ;
+
+fragment NONDIGIT
+    :   [a-zA-Z_]
     ;
 
 fragment LETTER

--- a/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
@@ -154,7 +154,7 @@ fragment DIGIT
     ;
 
 fragment NONDIGIT
-    :   [a-zA-Z_]
+    : [a-zA-Z_]
     ;
 
 fragment LETTER

--- a/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
@@ -82,7 +82,7 @@ STRING
     ;
 
 IDENTIFIER
-    : NONDIGIT (LETTER | DIGIT | '_')*
+    : (LETTER | '_') (LETTER|DIGIT| '_')*
     ;
 
 BACKQUOTED_IDENTIFIER
@@ -151,10 +151,6 @@ fragment EXPONENT
 
 fragment DIGIT
     : [0-9]
-    ;
-
-fragment NONDIGIT
-    : [a-zA-Z_]
     ;
 
 fragment LETTER

--- a/src/test/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommandTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommandTest.scala
@@ -39,7 +39,7 @@ class CreateModelCommandTest extends AnyFunSuite with SparkTestSession {
     spark
       .sql(
         "CREATE MODEL qualified_opt OPTIONS (" +
-          "rikai.foo.bar=1.23, foo='bar', num=-1.23, flag=True) " +
+          "rikai.foo.bar=1.23, foo='bar', num=-1.23, batch=10, flag=True) " +
           "USING 'test://foo/options'"
       )
       .count()
@@ -49,6 +49,7 @@ class CreateModelCommandTest extends AnyFunSuite with SparkTestSession {
         "foo" -> "bar",
         "num" -> "-1.23",
         "flag" -> "true",
+        "batch" -> "10",
         "rikai.foo.bar" -> "1.23"
       ).toMap
     )


### PR DESCRIPTION
Fix https://github.com/eto-ai/rikai/issues/222