### PR TITLE
Error Handling for MLflow protocol with 2 forward slashes

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Pip install
       working-directory: python
       run: |
+        sudo apt update
         sudo apt-get -y -qq install libsnappy-dev ffmpeg
         python -m pip install -e .[all,dev]
     - name: Python black and flake8

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ python/rikai/jars/
 .idea/
 .vscode/
 .DS_Store
+.python-version
 
 **/mlruns

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ model version if you're using the mlflow model registry.
 ```sql
 CREATE MODEL yolo5
 OPTIONS (min_confidence=0.3, device="gpu", batch_size=32)
-USING "mlflow:///yolo5_model/";
+USING "mlflow://yolo5_model/";
 
 SELECT id, ML_PREDICT(yolo5, image) FROM my_dataset
 WHERE split = "train" LIMIT 100;

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ model version if you're using the mlflow model registry.
 ```sql
 CREATE MODEL yolo5
 OPTIONS (min_confidence=0.3, device="gpu", batch_size=32)
-USING "mlflow://yolo5_model/";
+USING "mlflow:///yolo5_model/";
 
 SELECT id, ML_PREDICT(yolo5, image) FROM my_dataset
 WHERE split = "train" LIMIT 100;

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -217,7 +217,8 @@ class MlflowRegistry(Registry):
         parsed = urlparse(uri)
         if parsed.netloc:
             raise ValueError(
-                "URI with 2 forward slashes is not supported, try URI with 1 slash instead"
+                "URI with 2 forward slashes is not supported, "
+                "try URI with 1 slash instead"
             )
         if not parsed.scheme:
             raise ValueError("Scheme must be mlflow. How did you get here?")

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -215,6 +215,8 @@ class MlflowRegistry(Registry):
         uri = raw_spec.getUri()
         logger.info(f"Resolving model {name} from {uri}")
         parsed = urlparse(uri)
+        if parsed.netloc:
+            raise ValueError("MLflow protocol with 2 forward slashes is not supported")
         if not parsed.scheme:
             raise ValueError("Scheme must be mlflow. How did you get here?")
         parts = parsed.path.strip("/").split("/", 1)

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -216,7 +216,8 @@ class MlflowRegistry(Registry):
         logger.info(f"Resolving model {name} from {uri}")
         parsed = urlparse(uri)
         if parsed.netloc:
-            raise ValueError("URI with 2 forward slashes is not supported")
+            raise ValueError("URI with 2 forward slashes is not supported,"
+                + "try URI with 1 slash instead")
         if not parsed.scheme:
             raise ValueError("Scheme must be mlflow. How did you get here?")
         parts = parsed.path.strip("/").split("/", 1)

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -216,8 +216,9 @@ class MlflowRegistry(Registry):
         logger.info(f"Resolving model {name} from {uri}")
         parsed = urlparse(uri)
         if parsed.netloc:
-            raise ValueError("URI with 2 forward slashes is not supported,"
-                + "try URI with 1 slash instead")
+            raise ValueError(
+                "URI with 2 forward slashes is not supported, try URI with 1 slash instead"
+            )
         if not parsed.scheme:
             raise ValueError("Scheme must be mlflow. How did you get here?")
         parts = parsed.path.strip("/").split("/", 1)

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -215,11 +215,9 @@ class MlflowRegistry(Registry):
         uri = raw_spec.getUri()
         logger.info(f"Resolving model {name} from {uri}")
         parsed = urlparse(uri)
-        if parsed.netloc:
-            raise ValueError("URI with 2 forward slashes is not supported")
         if not parsed.scheme:
             raise ValueError("Scheme must be mlflow. How did you get here?")
-        parts = parsed.path.strip("/").split("/", 1)
+        parts = (parsed.netloc + parsed.path).strip("/").split("/", 1)
         model_uri, run = self.get_model_version(*parts)
         spec = MlflowModelSpec(
             model_uri,

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -216,7 +216,7 @@ class MlflowRegistry(Registry):
         logger.info(f"Resolving model {name} from {uri}")
         parsed = urlparse(uri)
         if parsed.netloc:
-            raise ValueError("MLflow protocol with 2 forward slashes is not supported")
+            raise ValueError("URI with 2 forward slashes is not supported")
         if not parsed.scheme:
             raise ValueError("Scheme must be mlflow. How did you get here?")
         parts = parsed.path.strip("/").split("/", 1)

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -215,9 +215,11 @@ class MlflowRegistry(Registry):
         uri = raw_spec.getUri()
         logger.info(f"Resolving model {name} from {uri}")
         parsed = urlparse(uri)
+        if parsed.netloc:
+            raise ValueError("URI with 2 forward slashes is not supported")
         if not parsed.scheme:
             raise ValueError("Scheme must be mlflow. How did you get here?")
-        parts = (parsed.netloc + parsed.path).strip("/").split("/", 1)
+        parts = parsed.path.strip("/").split("/", 1)
         model_uri, run = self.get_model_version(*parts)
         spec = MlflowModelSpec(
             model_uri,

--- a/python/tests/spark/sql/codegen/test_mlflow_registry.py
+++ b/python/tests/spark/sql/codegen/test_mlflow_registry.py
@@ -119,10 +119,15 @@ def test_mlflow_model_from_model_version(
     spark.sql("CREATE MODEL resnet_m_fizz USING 'mlflow:/rikai-test/1'")
     check_ml_predict(spark, "resnet_m_fizz")
 
+    spark.sql("CREATE MODEL resnet_m_fizz_2 USING 'mlflow://rikai-test/1'")
+    check_ml_predict(spark, "resnet_m_fizz_2")
+
     # use the latest version in a given stage (omitted means none)
-    spark.sql("CREATE MODEL resnet_m_buzz USING 'mlflow:/rikai-test'")
+    spark.sql("CREATE MODEL resnet_m_buzz using 'mlflow:/rikai-test'")
     check_ml_predict(spark, "resnet_m_buzz")
 
+    spark.sql("CREATE MODEL resnet_m_buzz_2 using 'mlflow://rikai-test'")
+    check_ml_predict(spark, "resnet_m_buzz_2")
 
 @pytest.mark.timeout(60)
 def test_mlflow_model_without_custom_logger(
@@ -154,20 +159,3 @@ def test_mlflow_model_without_custom_logger(
         ).format(pre_processing, post_processing, schema)
     )
     check_ml_predict(spark, "vanilla_fire")
-
-
-@pytest.mark.timeout(60)
-def test_mlflow_model_error_handling(
-    spark: SparkSession, mlflow_client: MlflowClient
-):
-    with pytest.raises(
-        py4j.protocol.Py4JJavaError,
-        match=r".*URI with 2 forward slashes is not supported.*",
-    ):
-        spark.sql("CREATE MODEL two_slash USING 'mlflow://vanilla-mlflow/1'")
-
-    with pytest.raises(
-        py4j.protocol.Py4JJavaError,
-        match=r".*Model registry scheme 'wrong' is not supported.*",
-    ):
-        spark.sql("CREATE MODEL wrong_uri USING 'wrong://vanilla-mlflow/1'")

--- a/python/tests/spark/sql/codegen/test_mlflow_registry.py
+++ b/python/tests/spark/sql/codegen/test_mlflow_registry.py
@@ -119,15 +119,10 @@ def test_mlflow_model_from_model_version(
     spark.sql("CREATE MODEL resnet_m_fizz USING 'mlflow:/rikai-test/1'")
     check_ml_predict(spark, "resnet_m_fizz")
 
-    spark.sql("CREATE MODEL resnet_m_fizz_2 USING 'mlflow://rikai-test/1'")
-    check_ml_predict(spark, "resnet_m_fizz_2")
-
     # use the latest version in a given stage (omitted means none)
-    spark.sql("CREATE MODEL resnet_m_buzz using 'mlflow:/rikai-test'")
+    spark.sql("CREATE MODEL resnet_m_buzz USING 'mlflow:/rikai-test'")
     check_ml_predict(spark, "resnet_m_buzz")
 
-    spark.sql("CREATE MODEL resnet_m_buzz_2 using 'mlflow://rikai-test'")
-    check_ml_predict(spark, "resnet_m_buzz_2")
 
 @pytest.mark.timeout(60)
 def test_mlflow_model_without_custom_logger(
@@ -159,3 +154,20 @@ def test_mlflow_model_without_custom_logger(
         ).format(pre_processing, post_processing, schema)
     )
     check_ml_predict(spark, "vanilla_fire")
+
+
+@pytest.mark.timeout(60)
+def test_mlflow_model_error_handling(
+    spark: SparkSession, mlflow_client: MlflowClient
+):
+    with pytest.raises(
+        py4j.protocol.Py4JJavaError,
+        match=r".*URI with 2 forward slashes is not supported.*",
+    ):
+        spark.sql("CREATE MODEL two_slash USING 'mlflow://vanilla-mlflow/1'")
+
+    with pytest.raises(
+        py4j.protocol.Py4JJavaError,
+        match=r".*Model registry scheme 'wrong' is not supported.*",
+    ):
+        spark.sql("CREATE MODEL wrong_uri USING 'wrong://vanilla-mlflow/1'")

--- a/python/tests/spark/sql/codegen/test_mlflow_registry.py
+++ b/python/tests/spark/sql/codegen/test_mlflow_registry.py
@@ -20,7 +20,7 @@ from pyspark.sql import Row, SparkSession
 from utils import check_ml_predict
 
 import rikai
-from rikai.spark.sql.codegen.mlflow_registry import MlflowModelSpec, MlflowRegistry
+from rikai.spark.sql.codegen.mlflow_registry import MlflowModelSpec
 from rikai.spark.sql.schema import parse_schema
 
 
@@ -155,18 +155,19 @@ def test_mlflow_model_without_custom_logger(
     )
     check_ml_predict(spark, "vanilla_fire")
 
+
 @pytest.mark.timeout(60)
 def test_mlflow_model_error_handling(
     spark: SparkSession, mlflow_client: MlflowClient
 ):
     with pytest.raises(
         py4j.protocol.Py4JJavaError,
-        match=r".*MLflow protocol with 2 forward slashes is not supported.*"
+        match=r".*URI with 2 forward slashes is not supported.*",
     ):
         spark.sql("CREATE MODEL two_slash USING 'mlflow://vanilla-mlflow/1'")
 
     with pytest.raises(
         py4j.protocol.Py4JJavaError,
-        match=r".*Model registry scheme 'wrong' is not supported.*"
+        match=r".*Model registry scheme 'wrong' is not supported.*",
     ):
-        spark.sql("CREATE MODEL wrong_protocol USING 'wrong://vanilla-mlflow/1'")
+        spark.sql("CREATE MODEL wrong_uri USING 'wrong://vanilla-mlflow/1'")

--- a/python/tests/spark/sql/codegen/test_mlflow_registry.py
+++ b/python/tests/spark/sql/codegen/test_mlflow_registry.py
@@ -123,12 +123,11 @@ def test_mlflow_model_from_model_version(
     check_ml_predict(spark, "resnet_m_fizz_2")
 
     # use the latest version in a given stage (omitted means none)
-    spark.sql("CREATE MODEL resnet_m_buzz USING 'mlflow:/rikai-test'")
+    spark.sql("CREATE MODEL resnet_m_buzz using 'mlflow:/rikai-test'")
     check_ml_predict(spark, "resnet_m_buzz")
 
-    spark.sql("CREATE MODEL resnet_m_buzz_2 USING 'mlflow://rikai-test'")
+    spark.sql("CREATE MODEL resnet_m_buzz_2 using 'mlflow://rikai-test'")
     check_ml_predict(spark, "resnet_m_buzz_2")
-
 
 @pytest.mark.timeout(60)
 def test_mlflow_model_without_custom_logger(

--- a/python/tests/spark/sql/codegen/test_mlflow_registry.py
+++ b/python/tests/spark/sql/codegen/test_mlflow_registry.py
@@ -123,11 +123,12 @@ def test_mlflow_model_from_model_version(
     check_ml_predict(spark, "resnet_m_fizz_2")
 
     # use the latest version in a given stage (omitted means none)
-    spark.sql("CREATE MODEL resnet_m_buzz using 'mlflow:/rikai-test'")
+    spark.sql("CREATE MODEL resnet_m_buzz USING 'mlflow:/rikai-test'")
     check_ml_predict(spark, "resnet_m_buzz")
 
-    spark.sql("CREATE MODEL resnet_m_buzz_2 using 'mlflow://rikai-test'")
+    spark.sql("CREATE MODEL resnet_m_buzz_2 USING 'mlflow://rikai-test'")
     check_ml_predict(spark, "resnet_m_buzz_2")
+
 
 @pytest.mark.timeout(60)
 def test_mlflow_model_without_custom_logger(


### PR DESCRIPTION
## Why `mlflow://` does not work
``` python
>>> from urllib.parse import urlparse
>>> p1 = urlparse("mlflow:/a/1")
>>> p2 = urlparse("mlflow://b/2")
>>> p3 = urlparse("mlflow:///c/3")
>>> p4 = urlparse("mlflow:////d/4")
>>> p1
ParseResult(scheme='mlflow', netloc='', path='/a/1', params='', query='', fragment='')
>>> p2
ParseResult(scheme='mlflow', netloc='b', path='/2', params='', query='', fragment='')
>>> p3
ParseResult(scheme='mlflow', netloc='', path='/c/3', params='', query='', fragment='')
>>> p4
ParseResult(scheme='mlflow', netloc='', path='//d/4', params='', query='', fragment='')
```

## How to test locally
```
sbt publishLocal
# Install python package
cd python
pip install -e . # pip install -e .[all] to install all optional extras (see "Install from pypi")
pytest tests/spark/sql/codegen/test_mlflow_registry.py -k test_mlflow_model_from_model_version
```