### PR TITLE
Support S3 fixture in unit test

### DIFF
--- a/python/rikai/io.py
+++ b/python/rikai/io.py
@@ -28,6 +28,7 @@ from pyarrow import fs
 # Rikai
 import rikai.conf
 from rikai.logging import logger
+import rikai.conf
 
 __all__ = ["copy", "open_uri", "open_output_stream"]
 

--- a/python/rikai/io.py
+++ b/python/rikai/io.py
@@ -28,7 +28,6 @@ from pyarrow import fs
 # Rikai
 import rikai.conf
 from rikai.logging import logger
-import rikai.conf
 
 __all__ = ["copy", "open_uri", "open_output_stream"]
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -25,7 +25,7 @@ dev = [
 ]
 torch = ["torch>=1.4.0", "torchvision"]
 jupyter = ["matplotlib", "jupyterlab"]
-aws = ["boto3"]
+aws = ["boto3", "botocore"]
 gcp = ["gcsfs"]
 docs = ["sphinx"]
 video = ["ffmpeg-python", "scenedetect"]

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -16,7 +16,6 @@ import logging
 import os
 import random
 import string
-from tempfile import tempdir
 import time
 import uuid
 from pathlib import Path

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -16,6 +16,7 @@ import logging
 import os
 import random
 import string
+from tempfile import tempdir
 import time
 import uuid
 from pathlib import Path
@@ -89,7 +90,8 @@ def asset_path() -> Path:
 def s3_tmpdir() -> str:
     """Create a temporary S3 directory to test dataset.
 
-    To enable s3 test, it requires both the AWS credentials, as well as `RIKAI_TEST_S3_BUCKET` being set.
+    To enable s3 test, it requires both the AWS credentials,
+    as well as `RIKAI_TEST_S3_BUCKET` being set.
     """
     bucket = os.environ.get("RIKAI_TEST_S3_BUCKET", None)
     if bucket is None:
@@ -110,7 +112,12 @@ def s3_tmpdir() -> str:
 
     if not bucket.startswith("s3://"):
         bucket = f"s3://{bucket}"
-    return f"{bucket}/{''.join(random.choices(string.ascii_letters + string.digits, k=6))}"
+    temp_dir = (
+        bucket
+        + "/"
+        + "".join(random.choices(string.ascii_letters + string.digits, k=6))
+    )
+    return temp_dir
 
 
 @pytest.fixture(scope="session")

--- a/python/tests/parquet/test_dataset.py
+++ b/python/tests/parquet/test_dataset.py
@@ -49,3 +49,6 @@ def test_select_columns(spark: SparkSession, tmp_path: Path):
 
 def test_select_columns_on_gcs(spark: SparkSession, gcs_tmpdir: str):
     _select_columns(spark, gcs_tmpdir)
+
+def test_select_over_s3(spark: SparkSession, s3_tmpdir: str):
+    _select_columns(spark, s3_tmpdir)

--- a/python/tests/parquet/test_dataset.py
+++ b/python/tests/parquet/test_dataset.py
@@ -50,5 +50,6 @@ def test_select_columns(spark: SparkSession, tmp_path: Path):
 def test_select_columns_on_gcs(spark: SparkSession, gcs_tmpdir: str):
     _select_columns(spark, gcs_tmpdir)
 
+
 def test_select_over_s3(spark: SparkSession, s3_tmpdir: str):
     _select_columns(spark, s3_tmpdir)


### PR DESCRIPTION
We can now use `s3_tmpdir` as test input fixture.

```
$ pytest tests/parquet/test_dataset.py -s -k s3
....
============================================================= 1 skipped, 1 deselected in 6.17s ==============================================================

$ RIKAI_TEST_S3_BUCKET=s3://accessible-bucket pytest tests/parquet/test_dataset.py -s -k s3
...
============================================================= 1 passed, 1 deselected in 37.37s ==============================================================
```

![Screen Shot 2021-08-23 at 8 23 37 PM](https://user-images.githubusercontent.com/17097/130550847-59dca370-a17f-4530-9498-1eb636d289e0.png)
