### PR TITLE
Fix for torch.Tensor.to

### DIFF
--- a/python/rikai/spark/sql/codegen/pytorch.py
+++ b/python/rikai/spark/sql/codegen/pytorch.py
@@ -71,7 +71,8 @@ def generate_udf(spec: "rikai.spark.sql.codegen.base.ModelSpec"):
                     batch_size=batch_size,
                     num_workers=num_workers,
                 ):
-                    batch = batch.to(device)
+                    if isinstance(batch, torch.Tensor):
+                        batch = batch.to(device)
                     predictions = model(batch)
                     if spec.post_processing:
                         predictions = spec.post_processing(predictions)


### PR DESCRIPTION
For the yolov5 model, we do not invoke pre_processing. Thus, batch in that case is not a `torch.Tensor`.

The error can be reproducible via https://github.com/da-tubi/rikai-example
```
$ python yolov5_mlflow.py
```

```
21/08/30 14:01:01 ERROR TaskSetManager: Task 0 in stage 0.0 failed 1 times; aborting job
Traceback (most recent call last):
  File "yolov5_mlflow.py", line 59, in <module>
    result.show(1, vertical=False, truncate=False)
  File "/Users/da/.pyenv/versions/rikai-example/lib/python3.8/site-packages/pyspark/sql/dataframe.py", line 486, in show
    print(self._jdf.showString(n, int(truncate), vertical))
  File "/Users/da/.pyenv/versions/rikai-example/lib/python3.8/site-packages/py4j/java_gateway.py", line 1304, in __call__
    return_value = get_return_value(
  File "/Users/da/.pyenv/versions/rikai-example/lib/python3.8/site-packages/pyspark/sql/utils.py", line 117, in deco
    raise converted from None
pyspark.sql.utils.PythonException:
  An exception was thrown from the Python worker. Please see the stack trace below.
Traceback (most recent call last):
  File "/Users/da/.pyenv/versions/3.8.10/envs/rikai-example/lib/python3.8/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 604, in main
    process()
  File "/Users/da/.pyenv/versions/3.8.10/envs/rikai-example/lib/python3.8/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 596, in process
    serializer.dump_stream(out_iter, outfile)
  File "/Users/da/.pyenv/versions/3.8.10/envs/rikai-example/lib/python3.8/site-packages/pyspark/python/lib/pyspark.zip/pyspark/sql/pandas/serializers.py", line 273, in dump_stream
    return ArrowStreamSerializer.dump_stream(self, init_stream_yield_batches(), stream)
  File "/Users/da/.pyenv/versions/3.8.10/envs/rikai-example/lib/python3.8/site-packages/pyspark/python/lib/pyspark.zip/pyspark/sql/pandas/serializers.py", line 81, in dump_stream
    for batch in iterator:
  File "/Users/da/.pyenv/versions/3.8.10/envs/rikai-example/lib/python3.8/site-packages/pyspark/python/lib/pyspark.zip/pyspark/sql/pandas/serializers.py", line 266, in init_stream_yield_batches
    for series in iterator:
  File "/Users/da/.pyenv/versions/3.8.10/envs/rikai-example/lib/python3.8/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 356, in func
    for result_batch, result_type in result_iter:
  File "/Users/da/.pyenv/versions/rikai-example/lib/python3.8/site-packages/rikai/spark/sql/codegen/pytorch.py", line 74, in torch_inference_udf
    batch = batch.to(device)
AttributeError: 'list' object has no attribute 'to'
```