### PR TITLE
explore codegen

### DIFF
--- a/src/main/scala/ai/eto/rikai/sql/spark/RikaiSparkSessionExtensions.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/RikaiSparkSessionExtensions.scala
@@ -19,7 +19,7 @@ import ai.eto.rikai.sql.spark.parser.{RikaiExtSqlParser, RikaiSparkSQLParser}
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo}
-import org.apache.spark.sql.rikai.expressions.{Area, IOU}
+import org.apache.spark.sql.rikai.expressions.{Area, CreateBox2d, IOU}
 
 /** Rikai SparkSession extensions to enable Spark SQL ML.
   */
@@ -50,5 +50,14 @@ class RikaiSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
       (exprs: Seq[Expression]) => IOU(exprs(0), exprs(1))
     )
 
+    extensions.injectFunction(
+      new FunctionIdentifier("box2d"),
+      new ExpressionInfo(
+        "org.apache.spark.sql.rikai.expressions",
+        "CreateBox2d"
+      ),
+      (exprs: Seq[Expression]) =>
+        CreateBox2d(exprs(0), exprs(1), exprs(2), exprs(3))
+    )
   }
 }

--- a/src/main/scala/org/apache/spark/sql/rikai/Box2d.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/Box2d.scala
@@ -112,6 +112,12 @@ class Box2d(
     f"Box2d(xmin=$xmin, ymin=$ymin, xmax=$xmax, ymax=$ymax)"
 }
 
+object Box2dUtils {
+  def iou(left: InternalRow, right: InternalRow): Double = {
+    Box2dType.deserialize(left).iou(Box2dType.deserialize(right))
+  }
+}
+
 /** User defined type of 2D Bouding Box
   */
 class Box2dType extends UserDefinedType[Box2d] {

--- a/src/test/scala/ai/eto/rikai/sql/spark/expressions/SqlFunctionTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/expressions/SqlFunctionTest.scala
@@ -49,18 +49,22 @@ class SqlFunctionTest extends AnyFunSuite with SparkTestSession {
 
     spark.sql("select box2d(0, 0, 20, 20)").show()
 
-    val q = spark.range(2).select(
-      F.col("id").as("id"),
-      F.rand(10).as("xmin"),
-      F.rand(10).as("ymin"),
-      F.lit(100).as("xmax"),
-      F.lit(100).as("ymax"),
-    ).selectExpr(
-      "box2d(xmin, ymin, xmax, ymax) as box1",
-      "box2d(xmin + 1, ymin + 1, xmax, ymax) as box2"
-    ).selectExpr(
-      "iou(box1, box2) as iou"
-    )
+    val q = spark
+      .range(2)
+      .select(
+        F.col("id").as("id"),
+        F.rand(10).as("xmin"),
+        F.rand(10).as("ymin"),
+        F.lit(100).as("xmax"),
+        F.lit(100).as("ymax")
+      )
+      .selectExpr(
+        "box2d(xmin, ymin, xmax, ymax) as box1",
+        "box2d(xmin + 1, ymin + 1, xmax, ymax) as box2"
+      )
+      .selectExpr(
+        "iou(box1, box2) as iou"
+      )
 
     q.show(10, 100, true)
   }


### PR DESCRIPTION
Using Box2d literals, Spark Optimizer will fold the constants, so that there is no chance to trigger the doGenCode method.

That's why we need an extra `box2d` udf to test the codegen part.