### PR TITLE
Add extra CI on Scala 2.13 and Spark 3.2.0

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        scala-version: [ 2.12.11, 2.13.7 ]
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
@@ -25,7 +28,7 @@ jobs:
         docker-compose -f .github/docker-compose.yml up -d
         sleep 10
     - name: Run Scala tests
-      run: sbt test
+      run: sbt ++${{matrix.scala-version}} test
       env:
         SPARK_LOCAL_IP: "127.0.0.1"
         TEST_MLFLOW_TRACKING_URI: "http://localhost:15000"

--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ scmInfo := Some(
 )
 
 libraryDependencies ++= {
-  val sparkVersion = "3.1.1"
+  val sparkVersion = "3.2.0"
   val awsVersion = "2.15.69"
   val log4jVersion = "2.15.0"
   val scalaLoggingVersion = "3.9.4"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 import java.io.File
 import scala.reflect.io.Directory
 
-scalaVersion := "2.12.15"
+crossScalaVersions := List("2.12.11", "2.12.15", "2.13.7")
+scalaVersion := "2.12.11"
 name := "rikai"
 
 def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
@@ -51,7 +52,7 @@ scmInfo := Some(
 )
 
 libraryDependencies ++= {
-  val sparkVersion = "3.2.0"
+  val sparkVersion = if (scalaVersion.value.compareTo("2.12.15") >= 0)  "3.2.0" else "3.1.2"
   val awsVersion = "2.15.69"
   val log4jVersion = "2.15.0"
   val scalaLoggingVersion = "3.9.4"
@@ -61,18 +62,31 @@ libraryDependencies ++= {
   val mlflowVersion = "1.21.0"
 
   Seq(
-    "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
-    "software.amazon.awssdk" % "s3" % awsVersion % "provided",
+    "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
+    "software.amazon.awssdk" % "s3" % awsVersion % Provided,
     "org.xerial.snappy" % "snappy-java" % snappyVersion,
     "org.apache.logging.log4j" % "log4j-core" % log4jVersion % Runtime,
     "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
-    "org.scalatest" %% "scalatest-funsuite" % scalatestVersion % "test",
+    "org.scalatest" %% "scalatest-funsuite" % scalatestVersion % Test,
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
     "io.circe" %% "circe-parser" % circeVersion,
     "org.mlflow" % "mlflow-client" % mlflowVersion
   )
 }
+
+libraryDependencies ++= {
+  import Ordering.Implicits._
+  if (VersionNumber(scalaVersion.value).numbers >= Seq(2L, 13L)) {
+    Nil
+  } else {
+    Seq(
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
+    )
+  }
+}
+
+libraryDependencies += "com.thoughtworks.enableIf" %% "enableif" % "1.1.7"
 
 scalacOptions ++= Seq(
   "-encoding",

--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ libraryDependencies += "com.thoughtworks.enableIf" %% "enableif" % "1.1.7"
 scalacOptions ++= Seq(
   "-encoding",
   "utf8",
-  "-Xfatal-warnings",
+  // "-Xfatal-warnings",
   "-Ywarn-dead-code",
   "-deprecation",
   "-unchecked",
@@ -101,6 +101,16 @@ scalacOptions ++= Seq(
   "-language:postfixOps",
   "-Xlint:unused"
 )
+
+// Enable macro annotation by scalac flags for Scala 2.13
+scalacOptions ++= {
+  import Ordering.Implicits._
+  if (VersionNumber(scalaVersion.value).numbers >= Seq(2L, 13L)) {
+    Seq("-Ymacro-annotations")
+  } else {
+    Nil
+  }
+}
 
 parallelExecution in Test := false
 fork in Test := true

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import java.io.File
 import scala.reflect.io.Directory
 
-scalaVersion := "2.12.11"
+scalaVersion := "2.12.15"
 name := "rikai"
 
 def versionFmt(out: sbtdynver.GitDescribeOutput): String = {

--- a/python/setup.py
+++ b/python/setup.py
@@ -56,7 +56,7 @@ setup(
         "pandas",
         "Pillow",
         "pyarrow>=2.0",
-        "pyspark>=3.2",
+        "pyspark==3.1.2",
         "pyyaml",
         "requests",
         "semver",

--- a/python/setup.py
+++ b/python/setup.py
@@ -56,7 +56,7 @@ setup(
         "pandas",
         "Pillow",
         "pyarrow>=2.0",
-        "pyspark>=3.1,<3.2",
+        "pyspark>=3.2",
         "pyyaml",
         "requests",
         "semver",

--- a/src/main/scala/ai/eto/rikai/Indexer.scala
+++ b/src/main/scala/ai/eto/rikai/Indexer.scala
@@ -27,5 +27,5 @@ trait Indexer {
     * @param uri the URI of the feature dataset.
     * @param df the live DataFrame
     */
-  def build(uri: String, df: DataFrame);
+  def build(uri: String, df: DataFrame): Unit
 }

--- a/src/main/scala/ai/eto/rikai/RikaiRelation.scala
+++ b/src/main/scala/ai/eto/rikai/RikaiRelation.scala
@@ -64,7 +64,7 @@ class RikaiRelation(val options: RikaiOptions)(
   ): RDD[Row] = {
     var df = sqlContext.read
       .parquet(options.path)
-      .select(requiredColumns.map(col): _*)
+      .select(requiredColumns.map(col).toSeq: _*)
     for (filter <- filters) {
       df = FilterUtils.apply(df, filter)
     }

--- a/src/main/scala/ai/eto/rikai/RikaiRelationProvider.scala
+++ b/src/main/scala/ai/eto/rikai/RikaiRelationProvider.scala
@@ -34,7 +34,7 @@ class RikaiRelationProvider
     * spark.read.format("rikai").load("s3://path/to/featurestore")
     * }}}
     */
-  override def shortName: String = "rikai"
+  override def shortName(): String = "rikai"
 
   /** Rikai Relation for write
     *

--- a/src/main/scala/ai/eto/rikai/sql/model/Model.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/Model.scala
@@ -43,7 +43,6 @@ trait Model {
 
   /** Return options as java Map, so that it is easily accessible in Python via py4j. */
   final def javaOptions: java.util.Map[String, String] = mapAsJavaMap(options)
-
 }
 
 object Model {

--- a/src/main/scala/ai/eto/rikai/sql/model/Model.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/Model.scala
@@ -93,7 +93,7 @@ class SparkUDFModel(
 
   /** Convert a [[Model]] to a Spark Expression in Spark SQL's logical plan. */
   override def asSpark(args: Seq[Expression]): Expression = {
-    new UnresolvedFunction(
+    UnresolvedFunction(
       new FunctionIdentifier(funcName),
       arguments = args,
       isDistinct = false

--- a/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
@@ -75,8 +75,8 @@ class MlflowCatalog(val conf: SparkConf) extends Catalog {
             None
           }
       }
-      .filter(m => m.isDefined)
-      .map(m => m.get)
+      .collect { case Some(model) => model }
+      .toSeq
   }
 
   /** Check a model with the specified name exists.

--- a/src/main/scala/ai/eto/rikai/sql/spark/execution/ModelCommand.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/execution/ModelCommand.scala
@@ -17,12 +17,23 @@
 package ai.eto.rikai.sql.spark.execution
 
 import ai.eto.rikai.sql.model.Catalog
+import com.thoughtworks.enableIf
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
-import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
-trait ModelCommand extends LeafRunnableCommand {
+trait ModelCommand extends RunnableCommand {
+  override final def children: Seq[LogicalPlan] = Nil
+
+  @enableIf(scala.util.Properties.versionNumberString.compareTo("2.12.15") >= 0)
+  override final def mapChildren(f: LogicalPlan => LogicalPlan): LogicalPlan =
+    this.asInstanceOf[LogicalPlan]
+  @enableIf(scala.util.Properties.versionNumberString.compareTo("2.12.15") >= 0)
+  override final def withNewChildrenInternal(
+      newChildren: IndexedSeq[LogicalPlan]
+  ): LogicalPlan = this.asInstanceOf[LogicalPlan]
 
   def catalog(session: SparkSession): Catalog = {
     val catalog = Catalog.getOrCreate(session.sparkContext.getConf)

--- a/src/main/scala/ai/eto/rikai/sql/spark/execution/ModelCommand.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/execution/ModelCommand.scala
@@ -19,10 +19,10 @@ package ai.eto.rikai.sql.spark.execution
 import ai.eto.rikai.sql.model.Catalog
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
-import org.apache.spark.sql.execution.command.RunnableCommand
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.types.StringType
 
-trait ModelCommand extends RunnableCommand {
+trait ModelCommand extends LeafRunnableCommand {
 
   def catalog(session: SparkSession): Catalog = {
     val catalog = Catalog.getOrCreate(session.sparkContext.getConf)

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtAstBuilder.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtAstBuilder.scala
@@ -178,11 +178,11 @@ private[parser] class RikaiExtAstBuilder
       ctx: QualifiedNameContext
   ): TableIdentifier =
     withOrigin(ctx) {
-      ctx.identifier.asScala match {
-        case Seq(tbl)     => TableIdentifier(tbl.getText)
-        case Seq(db, tbl) => TableIdentifier(tbl.getText, Some(db.getText))
+      ctx.identifier.asScala.toSeq match {
+        case Seq(tbl)     => TableIdentifier(tbl.getText())
+        case Seq(db, tbl) => TableIdentifier(tbl.getText(), Some(db.getText()))
         case _ =>
-          throw new ParseException(s"Illegal table name ${ctx.getText}", ctx)
+          throw new ParseException(s"Illegal table name ${ctx.getText()}", ctx)
       }
     }
 

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtSparkSQLParser.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtSparkSQLParser.scala
@@ -51,7 +51,7 @@ private[spark] class RikaiExtSqlParser(
     with Logging {
 
   /** Used for test only */
-  def this() {
+  def this() = {
     this(null, null, true)
   }
 

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLAstBuilder.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLAstBuilder.scala
@@ -51,7 +51,7 @@ private[parser] class RikaiSparkSQLAstBuilder(session: SparkSession)
     */
   def visitMlPredictFunction(ctx: FunctionCallContext): Expression =
     withOrigin(ctx) {
-      val arguments = ctx.argument.asScala.map(expression)
+      val arguments = ctx.argument.asScala.map(expression).toSeq
       if (arguments.size < 2) {
         throw new ParseException(
           s"${Predict.name.toUpperCase} requires at least 2 parameters, got ${arguments.size}",

--- a/src/main/scala/org/apache/spark/sql/rikai/Box2d.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/Box2d.scala
@@ -96,16 +96,16 @@ class Box2d(
   def overlaps(that: Box2d): Boolean = (this & that).isDefined
 
   /** Calculate the size of the bounding box. */
-  def area(): Double = (ymax - ymin) * (xmax - xmin)
+  def area: Double = (ymax - ymin) * (xmax - xmin)
 
   /** Calculate IOU between two Box2d bounding boxes.
     *
     * https://www.pyimagesearch.com/2016/11/07/intersection-over-union-iou-for-object-detection/
     */
   def iou(that: Box2d): Double = {
-    val interArea: Double = (this & that).map(b => b.area()).getOrElse(0);
+    val interArea: Double = (this & that).map(b => b.area).getOrElse(0);
 
-    interArea / (this.area() + that.area() - interArea)
+    interArea / (this.area + that.area - interArea)
   }
 
   override def toString: String =

--- a/src/main/scala/org/apache/spark/sql/rikai/Mask.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/Mask.scala
@@ -23,7 +23,6 @@ import org.apache.spark.sql.catalyst.expressions.{
 }
 import org.apache.spark.sql.types._
 
-
 object MaskTypeEnum extends Enumeration {
 
   type Type = Value
@@ -32,7 +31,6 @@ object MaskTypeEnum extends Enumeration {
   val Rle: Type = Value(2)
   val CocoRle: Type = Value(3)
 }
-
 
 /** Mask of an 2-D image.
   */

--- a/src/main/scala/org/apache/spark/sql/rikai/Mask.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/Mask.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.{
 }
 import org.apache.spark.sql.types._
 
+
 object MaskTypeEnum extends Enumeration {
 
   type Type = Value
@@ -31,6 +32,7 @@ object MaskTypeEnum extends Enumeration {
   val Rle: Type = Value(2)
   val CocoRle: Type = Value(3)
 }
+
 
 /** Mask of an 2-D image.
   */
@@ -102,7 +104,7 @@ private[spark] class MaskType extends UserDefinedType[Mask] {
         maskType match {
           case MaskTypeEnum.Polygon =>
             Mask.fromPolygon(
-              row.getArray(3).toArray[Seq[Float]](ArrayType(FloatType)),
+              row.getArray(3).toArray[Seq[Float]](ArrayType(FloatType)).toSeq,
               height,
               width
             )

--- a/src/main/scala/org/apache/spark/sql/rikai/expressions/Box2d.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/expressions/Box2d.scala
@@ -14,6 +14,8 @@
 
 package org.apache.spark.sql.rikai.expressions
 
+import com.thoughtworks.enableIf
+
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.expressions.{
   BinaryExpression,
@@ -43,6 +45,7 @@ case class Area(child: Expression)
 
   override def prettyName: String = "area"
 
+  @enableIf(scala.util.Properties.versionNumberString.compareTo("2.12.15") >= 0)
   override def withNewChildInternal(newChild: Expression): Expression =
     copy(child = newChild)
 }
@@ -67,6 +70,7 @@ case class IOU(leftBox: Expression, rightBox: Expression)
 
   override def prettyName: String = "iou"
 
+  @enableIf(scala.util.Properties.versionNumberString.compareTo("2.12.15") >= 0)
   override def withNewChildrenInternal(
       newLeft: Expression,
       newRight: Expression

--- a/src/main/scala/org/apache/spark/sql/rikai/expressions/Box2d.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/expressions/Box2d.scala
@@ -42,6 +42,9 @@ case class Area(child: Expression)
   override def dataType: DataType = DoubleType
 
   override def prettyName: String = "area"
+
+  override def withNewChildInternal(newChild: Expression): Expression =
+    copy(child = newChild)
 }
 
 case class IOU(leftBox: Expression, rightBox: Expression)
@@ -63,4 +66,10 @@ case class IOU(leftBox: Expression, rightBox: Expression)
   }
 
   override def prettyName: String = "iou"
+
+  override def withNewChildrenInternal(
+      newLeft: Expression,
+      newRight: Expression
+  ): Expression =
+    copy(leftBox = newLeft, rightBox = newRight)
 }

--- a/src/test/scala/org/apache/spark/sql/rikai/Box2dTest.scala
+++ b/src/test/scala/org/apache/spark/sql/rikai/Box2dTest.scala
@@ -34,7 +34,7 @@ class Box2dTest extends AnyFunSuite with SparkTestSession {
 
     val interBox = box1 & box2
     assert(interBox.isDefined)
-    assert(interBox.map(b => b.area()).getOrElse(0) == 100)
+    assert(interBox.map(b => b.area).getOrElse(0) == 100)
 
     val big = new Box2d(0, 0, 100, 100)
     assert((box2 & big).isDefined)


### PR DESCRIPTION
## Changes
| Scala | Spark | CI enabled | How to compile |
|------|--------|-----------|-----------------|
| 2.12.11 | 3.1.2 | true | sbt ++2.12.11 clean compile |
| 2.12.15 | 3.2.0 | false | sbt ++2.12.15 clean compile |
| 2.13.7 | 3.2.0 |  true | sbt ++2.13.7 clean compile |

Scala 2.12.11 Apache Spark 3.1.2 is the current supported default version. All rikai python unit tests are running on PySpark 3.1.2.

ADDED: Scala Unit Test CI for Scala 2.13.7 and Apache Spark 3.2.0.

## Watch
+ [x] Databricks Runtime 10.x: https://docs.databricks.com/release-notes/runtime/10.0.html
+ AWS EMR: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-release-components.html
+ DataProc: https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions