### PR TITLE
Use BinaryType as the ML_PREDICT input for yolov5

### DIFF
--- a/python/rikai/contrib/torch/transforms/yolov5.py
+++ b/python/rikai/contrib/torch/transforms/yolov5.py
@@ -24,8 +24,16 @@ pip install yolov5
 """  # noqa E501
 
 from typing import Any, Callable, Dict
+import pickle
 
-__all__ = ["post_processing", "OUTPUT_SCHEMA"]
+__all__ = ["pre_processing", "post_processing", "OUTPUT_SCHEMA"]
+
+
+def _pre_process_func(image_binary):
+    return pickle.loads(image_binary)
+
+def pre_processing(options: Dict[str, Any]) -> Callable:
+    return _pre_process_func
 
 
 def post_processing(options: Dict[str, Any]) -> Callable:

--- a/python/rikai/contrib/torch/transforms/yolov5.py
+++ b/python/rikai/contrib/torch/transforms/yolov5.py
@@ -23,8 +23,8 @@ pip install yolov5
 ```
 """  # noqa E501
 
-from typing import Any, Callable, Dict
 import pickle
+from typing import Any, Callable, Dict
 
 __all__ = ["pre_processing", "post_processing", "OUTPUT_SCHEMA"]
 

--- a/python/rikai/contrib/torch/transforms/yolov5.py
+++ b/python/rikai/contrib/torch/transforms/yolov5.py
@@ -32,6 +32,7 @@ __all__ = ["pre_processing", "post_processing", "OUTPUT_SCHEMA"]
 def _pre_process_func(image_binary):
     return pickle.loads(image_binary)
 
+
 def pre_processing(options: Dict[str, Any]) -> Callable:
     return _pre_process_func
 

--- a/python/rikai/contrib/torch/transforms/yolov5.py
+++ b/python/rikai/contrib/torch/transforms/yolov5.py
@@ -24,13 +24,14 @@ pip install yolov5
 """  # noqa E501
 
 from typing import Any, Callable, Dict
+
 from rikai.types.vision import Image
 
 __all__ = ["pre_processing", "post_processing", "OUTPUT_SCHEMA"]
 
 
 def _pre_process_func(image_data):
-    return Image(image_data).to_numpy()
+    return Image(image_data).to_pil()
 
 
 def pre_processing(options: Dict[str, Any]) -> Callable:

--- a/python/rikai/contrib/torch/transforms/yolov5.py
+++ b/python/rikai/contrib/torch/transforms/yolov5.py
@@ -23,14 +23,14 @@ pip install yolov5
 ```
 """  # noqa E501
 
-import pickle
 from typing import Any, Callable, Dict
+from rikai.types.vision import Image
 
 __all__ = ["pre_processing", "post_processing", "OUTPUT_SCHEMA"]
 
 
-def _pre_process_func(image_binary):
-    return pickle.loads(image_binary)
+def _pre_process_func(image_data):
+    return Image(image_data).to_numpy()
 
 
 def pre_processing(options: Dict[str, Any]) -> Callable:

--- a/python/rikai/spark/sql/codegen/pytorch.py
+++ b/python/rikai/spark/sql/codegen/pytorch.py
@@ -27,6 +27,8 @@ from rikai.torch.pandas import PandasDataset
 DEFAULT_NUM_WORKERS = 8
 DEFAULT_BATCH_SIZE = 4
 
+def _identity(x):
+    return x
 
 def generate_udf(spec: "rikai.spark.sql.codegen.base.ModelSpec"):
     """Construct a UDF to run pytorch model.
@@ -65,12 +67,25 @@ def generate_udf(spec: "rikai.spark.sql.codegen.base.ModelSpec"):
         with torch.no_grad():
             for series in iter:
                 dataset = PandasDataset(series, transform=spec.pre_processing)
+
+                if isinstance(dataset[0], torch.Tensor):
+                    dataloader = DataLoader(
+                        dataset,
+                        batch_size=batch_size,
+                        num_workers=num_workers,
+                    )
+                else:
+                    # Keep the data type as it is and avoid the collate_fn
+                    # of DataLoader from converting numpy.ndarray to torch.Tensor
+                    dataloader = DataLoader(
+                        dataset,
+                        batch_size=batch_size,
+                        num_workers=num_workers,
+                        collate_fn=_identity
+                    )
+
                 results = []
-                for batch in DataLoader(
-                    dataset,
-                    batch_size=batch_size,
-                    num_workers=num_workers,
-                ):
+                for batch in dataloader:
                     if isinstance(batch, torch.Tensor):
                         batch = batch.to(device)
                     predictions = model(batch)

--- a/python/rikai/spark/sql/codegen/pytorch.py
+++ b/python/rikai/spark/sql/codegen/pytorch.py
@@ -27,8 +27,10 @@ from rikai.torch.pandas import PandasDataset
 DEFAULT_NUM_WORKERS = 8
 DEFAULT_BATCH_SIZE = 4
 
+
 def _identity(x):
     return x
+
 
 def generate_udf(spec: "rikai.spark.sql.codegen.base.ModelSpec"):
     """Construct a UDF to run pytorch model.
@@ -81,7 +83,7 @@ def generate_udf(spec: "rikai.spark.sql.codegen.base.ModelSpec"):
                         dataset,
                         batch_size=batch_size,
                         num_workers=num_workers,
-                        collate_fn=_identity
+                        collate_fn=_identity,
                     )
 
                 results = []

--- a/python/rikai/spark/sql/codegen/pytorch.py
+++ b/python/rikai/spark/sql/codegen/pytorch.py
@@ -77,8 +77,8 @@ def generate_udf(spec: "rikai.spark.sql.codegen.base.ModelSpec"):
                         num_workers=num_workers,
                     )
                 else:
-                    # Keep the data type as it is and avoid the collate_fn
-                    # of DataLoader from converting numpy.ndarray to torch.Tensor
+                    # Keep the data type as it is and avoid the collate_fn of
+                    # DataLoader from converting numpy.ndarray to torch.Tensor
                     dataloader = DataLoader(
                         dataset,
                         batch_size=batch_size,


### PR DESCRIPTION
I recommend that reviewing https://github.com/eto-ai/rikai/pull/344 first and then this pull request. These two PRs are actually orthogonal。

## Why
Because UDT (ImageType) currently is not supported in `pandas_udf`

We could load a video into a dataframe of images in BinaryType (the data part of the ImageType). And we can convert the binary data into pil Image during `pre_processing`.

Last time, I tried to convert the binary data to `numpy.ndarray`. It does not work due to the PyTorch Loader. Since we can use pil Image as the model input (after pre_processing). This PR becomes a nice-to-have PR now.

## Demo Usage on Video
https://github.com/da-tubi/rikai-example/blob/feature/direct_on_video/elephants_dream.ipynb
https://github.com/da-tubi/rikai-example/blob/feature/direct_on_video/elephants_dream.py