### PR TITLE
downgrade pytorch to 1.8.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - pytest=6.1.2
   - python=3.7.8
   - python-snappy=0.5.4
-  - pytorch=1.8.0
+  - pytorch=1.8.1
   - requests=2.24.0
   - scikit-learn=0.23.2
   - scipy=1.5.2
@@ -35,5 +35,5 @@ dependencies:
   - sqlalchemy=1.3.20
   - sqlite=3.33.0
   - tini=0.18.0
-  - torchvision=0.11.0
+  - torchvision=0.9.1
   - widgetsnbextension=3.5.1

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - pytest=6.1.2
   - python=3.7.8
   - python-snappy=0.5.4
-  - pytorch=1.9.0
+  - pytorch=1.8.0
   - requests=2.24.0
   - scikit-learn=0.23.2
   - scipy=1.5.2

--- a/python/deps/requirements_rtd.txt
+++ b/python/deps/requirements_rtd.txt
@@ -6,6 +6,7 @@ Pillow
 pyarrow>=2.0
 pycocotools==2.0.2
 pyspark>=3
-torch>=1.9.0
+torch>=1.8.0
+torchvision>=0.11.0
 pyyaml
 semver

--- a/python/deps/requirements_rtd.txt
+++ b/python/deps/requirements_rtd.txt
@@ -6,7 +6,7 @@ Pillow
 pyarrow>=2.0
 pycocotools==2.0.2
 pyspark>=3
-torch>=1.8.0
-torchvision>=0.11.0
+torch>=1.8.1
+torchvision>=0.9.1
 pyyaml
 semver

--- a/python/setup.py
+++ b/python/setup.py
@@ -24,7 +24,7 @@ dev = [
     "wheel",
 ]
 sklearn = ["scikit-learn"]
-torch = ["torch>=1.8.0", "torchvision>=0.11.0"]
+torch = ["torch>=1.8.1", "torchvision>=0.9.1"]
 jupyter = ["matplotlib", "jupyterlab"]
 aws = ["boto3", "botocore"]
 gcp = ["gcsfs"]

--- a/python/setup.py
+++ b/python/setup.py
@@ -24,7 +24,7 @@ dev = [
     "wheel",
 ]
 sklearn = ["scikit-learn"]
-torch = ["torch>=1.9.0", "torchvision>=0.11.0"]
+torch = ["torch>=1.8.0", "torchvision>=0.11.0"]
 jupyter = ["matplotlib", "jupyterlab"]
 aws = ["boto3", "botocore"]
 gcp = ["gcsfs"]


### PR DESCRIPTION
Related issue: https://github.com/eto-ai/rikai/issues/342
Related pr: https://github.com/eto-ai/rikai/pull/347

Downgrade PyTorch version to align with Databricks platform, but we can still get rid of a customized `Dataloader`, we can upgrade it again when Databricks platform upgrades.