### PR TITLE
udf: array_box2d, inspect_bbox

### DIFF
--- a/python/rikai/spark/functions/geometry.py
+++ b/python/rikai/spark/functions/geometry.py
@@ -14,9 +14,12 @@
 
 """Geometry related PySpark UDF"""
 
+# Standard library
+from typing import List
+
 # Third Party
 from pyspark.sql.functions import udf
-from pyspark.sql.types import FloatType
+from pyspark.sql.types import ArrayType, FloatType
 
 # Rikai
 from rikai.logging import logger
@@ -30,6 +33,15 @@ __all__ = ["area", "box2d", "box2d_from_center", "box2d_from_top_left"]
 def box2d(coords) -> Box2d:
     """Build a Box2d from ``[xmin,ymin,xmax,ymax]`` array."""
     return Box2d(coords[0], coords[1], coords[2], coords[3])
+
+
+@udf(returnType=ArrayType(Box2dType()))
+def array_box2d(arr_coords) -> List[Box2d]:
+    """Build a Box2d from array of ``[xmin,ymin,xmax,ymax]`` arrays."""
+    result = []
+    for coords in arr_coords:
+        result.append(Box2d(coords[0], coords[1], coords[2], coords[3]))
+    return result
 
 
 @udf(returnType=Box2dType())


### PR DESCRIPTION
Why we need `array_box2d`, because:

``` sql
select inspect_bbox(image, transform(pred.boxes, x -> array_box2d(x)), transform(pred.label_id, i -> string(i)))
```

```
Error in SQL statement: UnsupportedOperationException: Cannot generate code for expression: inspect_bbox(input[4, image, true], transform(input[3, struct<boxes:array<array<float>>,label_ids:array<int>>, true].boxes, lambdafunction(box2d(lambda arr#393), lambda arr#393, false)), transform(input[3, struct<boxes:array<array<float>>,label_ids:array<int>>, true].label_ids, lambdafunction(cast(lambda i#394 as string), lambda i#394, false)))
```