### PR TITLE
Lazy loading on cv2

### DIFF
--- a/python/rikai/types/video.py
+++ b/python/rikai/types/video.py
@@ -15,8 +15,6 @@
 """Video related types and utils"""
 from abc import ABC, abstractmethod
 
-import cv2
-
 from rikai.mixin import Displayable, ToDict
 from rikai.spark.types import SegmentType, VideoStreamType, YouTubeVideoType
 
@@ -277,6 +275,8 @@ class SingleFrameSampler(VideoSampler):
 
     def __iter__(self):
         # TODO use seek for sparse sampling and maybe multithreaded
+        import cv2
+
         cap = cv2.VideoCapture(self.stream.uri)
         if self.start_frame > 0:
             cap.set(cv2.CAP_PROP_POS_FRAMES, self.start_frame)


### PR DESCRIPTION
Context: running rikai on a machine that has not `apt-get install opencv`. 

`cv2` is leaked if video package is not installed.

```
Traceback (most recent call last):
  File "/opt/coco.py", line 19, in <module>
    from rikai.types import Box2d, Image
  File "/usr/local/lib/python3.9/site-packages/rikai/types/__init__.py", line 22, in <module>
    from rikai.types.video import *
  File "/usr/local/lib/python3.9/site-packages/rikai/types/video.py", line 18, in <module>
    import cv2
  File "/usr/local/lib/python3.9/site-packages/cv2/__init__.py", line 8, in <module>
    from .cv2 import *
ImportError: libGL.so.1: cannot open shared object file: No such file or directory
```