### PR TITLE
[PARQUET] Set default scheme

### DIFF
--- a/python/rikai/parquet/resolver.py
+++ b/python/rikai/parquet/resolver.py
@@ -127,14 +127,26 @@ class DefaultResolver(BaseResolver):
 class Resolver:
     """Extensible Dataset Resolver"""
 
-    _DEFAULT_SCHEME = "_DEFAULT"
+    _UNKNOWN_SCHEME = "_DEFAULT"
     # Mapping from scheme to a daaset resolver
-    _RESOLVERS: Dict[str, BaseResolver] = {_DEFAULT_SCHEME: DefaultResolver()}
+    _RESOLVERS: Dict[str, BaseResolver] = {_UNKNOWN_SCHEME: DefaultResolver()}
+    DEFAULT_SCHEME = None
 
     @classmethod
     def reset(cls):
         """Reset Resolver for testing purpose."""
-        cls._RESOLVERS = {cls._DEFAULT_SCHEME: DefaultResolver()}
+        cls._RESOLVERS = {cls._UNKNOWN_SCHEME: DefaultResolver()}
+
+    @classmethod
+    def set_default_scheme(cls, default_scheme: str):
+        """Changes the default scheme when none is given in the uri.
+
+        Parameters
+        ----------
+        default_scheme: str
+            If the uri doesn't have a scheme then the resolver for this scheme is used
+        """
+        Resolver.DEFAULT_SCHEME = default_scheme
 
     @classmethod
     def register(cls, scheme: str, resolver: BaseResolver):
@@ -162,11 +174,11 @@ class Resolver:
     def resolve(cls, uri: Union[str, Path]) -> Iterable[str]:
         """Resolve the dataset URI, and returns a list of parquet files."""
         uri = str(uri)
-        parsed = urlparse(uri)
-        if parsed.scheme in cls._RESOLVERS:
-            logger.debug("Use extended resolver for scheme: %s", parsed.scheme)
-            return cls._RESOLVERS[parsed.scheme].resolve(uri)
-        return cls._RESOLVERS[cls._DEFAULT_SCHEME].resolve(uri)
+        scheme = cls._parse_scheme(uri)
+        if scheme in cls._RESOLVERS:
+            logger.debug("Use extended resolver for scheme: %s", scheme)
+            return cls._RESOLVERS[scheme].resolve(uri)
+        return cls._RESOLVERS[cls._UNKNOWN_SCHEME].resolve(uri)
 
     @classmethod
     def get_schema(cls, uri: str):
@@ -177,11 +189,15 @@ class Resolver:
         uri : str
             URI of the dataset
         """
-        parsed = urlparse(uri)
-        if parsed.scheme in cls._RESOLVERS:
-            logger.debug("Use extended resolver for scheme: %s", parsed.scheme)
-            return cls._RESOLVERS[parsed.scheme].get_schema(uri)
-        return cls._RESOLVERS[cls._DEFAULT_SCHEME].get_schema(uri)
+        scheme = cls._parse_scheme(uri)
+        if scheme in cls._RESOLVERS:
+            logger.debug("Use extended resolver for scheme: %s", scheme)
+            return cls._RESOLVERS[scheme].get_schema(uri)
+        return cls._RESOLVERS[cls._UNKNOWN_SCHEME].get_schema(uri)
+
+    @classmethod
+    def _parse_scheme(cls, uri):
+        return urlparse(uri).scheme or cls.DEFAULT_SCHEME
 
 
 def register(scheme: str):

--- a/python/rikai/parquet/resolver.py
+++ b/python/rikai/parquet/resolver.py
@@ -144,7 +144,7 @@ class Resolver:
         Parameters
         ----------
         default_scheme: str
-            If the uri doesn't have a scheme then the resolver for this scheme is used
+            If a uri has no scheme then the resolver for this scheme is used
         """
         Resolver.DEFAULT_SCHEME = default_scheme
 

--- a/python/rikai/parquet/resolver.py
+++ b/python/rikai/parquet/resolver.py
@@ -168,7 +168,7 @@ class Resolver:
         """
         if scheme in cls._RESOLVERS:
             raise KeyError(f"scheme f{scheme} has already been registered")
-        cls._RESOLVERS[scheme] = resolver()
+        cls._RESOLVERS[scheme] = resolver
 
     @classmethod
     def resolve(cls, uri: Union[str, Path]) -> Iterable[str]:

--- a/python/tests/parquet/test_resolver.py
+++ b/python/tests/parquet/test_resolver.py
@@ -18,7 +18,6 @@ from rikai.testing import assert_count_equal
 
 
 class TestResolver(BaseResolver):
-
     def resolve(self, uri: str) -> Iterable[str]:
         return ["test_uri"]
 
@@ -48,7 +47,7 @@ def test_resolve_empty_dir(tmp_path):
 
 def test_default_scheme(tmp_path):
     test_resolve_local_fs(tmp_path)
-    Resolver.register('test', TestResolver())
+    Resolver.register("test", TestResolver())
     Resolver.set_default_scheme("test")
     try:
         files = Resolver.resolve(tmp_path)

--- a/python/tests/parquet/test_resolver.py
+++ b/python/tests/parquet/test_resolver.py
@@ -12,8 +12,17 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from rikai.parquet.resolver import Resolver
+from rikai.parquet.resolver import BaseResolver, register, Resolver
 from rikai.testing import assert_count_equal
+
+
+@register("test")
+class TestResolver(BaseResolver):
+    def resolve(self, uri):
+        return ["test_uri"]
+
+    def get_schema(self, uri):
+        return {"type": "struct", "fields": [{"name": "id", "type": "long"}]}
 
 
 def teardown_function(_):
@@ -34,3 +43,15 @@ def test_resolve_local_fs(tmp_path):
 
 def test_resolve_empty_dir(tmp_path):
     assert [] == list(Resolver.resolve(tmp_path))
+
+
+def test_default_scheme(tmp_path):
+    test_resolve_local_fs(tmp_path)
+    Resolver.set_default_scheme("test")
+    try:
+        files = Resolver.resolve(tmp_path)
+        expected_files = ["test_uri"]
+        assert_count_equal(expected_files, files)
+        assert files[0] == expected_files[0]
+    finally:
+        Resolver.set_default_scheme(None)

--- a/python/tests/parquet/test_resolver.py
+++ b/python/tests/parquet/test_resolver.py
@@ -11,17 +11,18 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Iterable
 
 from rikai.parquet.resolver import BaseResolver, register, Resolver
 from rikai.testing import assert_count_equal
 
 
-@register("test")
 class TestResolver(BaseResolver):
-    def resolve(self, uri):
+
+    def resolve(self, uri: str) -> Iterable[str]:
         return ["test_uri"]
 
-    def get_schema(self, uri):
+    def get_schema(self, uri: str):
         return {"type": "struct", "fields": [{"name": "id", "type": "long"}]}
 
 
@@ -47,6 +48,7 @@ def test_resolve_empty_dir(tmp_path):
 
 def test_default_scheme(tmp_path):
     test_resolve_local_fs(tmp_path)
+    Resolver.register('test', TestResolver())
     Resolver.set_default_scheme("test")
     try:
         files = Resolver.resolve(tmp_path)


### PR DESCRIPTION
This is a convenience feature so that users can omit
the scheme of the dataset uri if they will always be
the same.