### PR TITLE
Do not ship gcs-connector-hadoop3-2.2.2-shaded.jar by default

### DIFF
--- a/python/rikai/spark/utils.py
+++ b/python/rikai/spark/utils.py
@@ -62,14 +62,6 @@ def init_spark_session(conf=None, app_name="rikai", rikai_version=None):
             ),
         )
         .config(
-            # Sadly we have to use a shaded gcs connector due to guava
-            # conflicts with Spark 3.1
-            "spark.jars",
-            "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/"
-            "gcs-connector/hadoop3-2.2.2/"
-            "gcs-connector-hadoop3-2.2.2-shaded.jar",
-        )
-        .config(
             "spark.sql.extensions",
             "ai.eto.rikai.sql.spark.RikaiSparkSessionExtensions",
         )

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -143,6 +143,14 @@ def spark(mlflow_tracking_uri: str) -> SparkSession:
                         ]
                     ),
                 ),
+                (
+                    # Sadly we have to use a shaded gcs connector due to guava
+                    # conflicts with Spark 3.1
+                    "spark.jars",
+                    "https://repo1.maven.org/maven2/com/google/cloud/"
+                    "bigdataoss/gcs-connector/hadoop3-2.2.2/"
+                    "gcs-connector-hadoop3-2.2.2-shaded.jar",
+                ),
                 ("spark.port.maxRetries", 128),
                 (
                     "rikai.sql.ml.registry.test.impl",


### PR DESCRIPTION
To reduce unnecessary dependencies.