### PR TITLE
Do not use height/width when construct polygon

### DIFF
--- a/contrib/coco/tests/test_convert.py
+++ b/contrib/coco/tests/test_convert.py
@@ -32,9 +32,7 @@ def test_covert_segmentation():
         ann_ids = coco.getAnnIds(imgIds=image_id)
         for ann in coco.loadAnns(ann_ids):
             if ann["iscrowd"] == 0:
-                mask = Mask.from_polygon(
-                    ann["segmentation"], height=height, width=width
-                )
+                mask = Mask.from_polygon(ann["segmentation"])
                 # TODO: currently, it has disparity of the conversion between
                 # polygon to mask between coco and rikai (PIL based)
             else:

--- a/python/rikai/spark/types/__init__.py
+++ b/python/rikai/spark/types/__init__.py
@@ -30,7 +30,12 @@ from pyspark.sql.types import (
 
 # Rikai
 import rikai
-from rikai.spark.types.geometry import Box2dType, Box3dType, PointType
+from rikai.spark.types.geometry import (
+    Box2dType,
+    Box3dType,
+    MaskType,
+    PointType,
+)
 from rikai.spark.types.video import (
     SegmentType,
     VideoStreamType,
@@ -46,6 +51,7 @@ __all__ = [
     "Box2dType",
     "VideoStreamType",
     "YouTubeVideoType",
+    "MaskType",
     "SegmentType",
 ]
 

--- a/python/rikai/spark/types/geometry.py
+++ b/python/rikai/spark/types/geometry.py
@@ -159,13 +159,11 @@ class MaskType(UserDefinedType):
 
     @classmethod
     def sqlType(cls) -> StructType:
-        from rikai.numpy import NDArrayType
-
         return StructType(
             fields=[
                 StructField("type", ShortType(), False),
-                StructField("height", IntegerType(), False),
-                StructField("width", IntegerType(), False),
+                StructField("height", IntegerType(), True),
+                StructField("width", IntegerType(), True),
                 StructField(
                     "polygon",
                     ArrayType(ArrayType(FloatType(), False), False),
@@ -201,7 +199,7 @@ class MaskType(UserDefinedType):
         height = datum[1]
         width = datum[2]
         if mask_type == Mask.Type.POLYGON:
-            return Mask.from_polygon(datum[3], height=height, width=width)
+            return Mask.from_polygon(datum[3])
         elif mask_type == Mask.Type.RLE:
             return Mask.from_rle(datum[4], height=height, width=width)
         elif mask_type == Mask.Type.COCO_RLE:

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -514,7 +514,9 @@ class Mask(ToNumpy, ToDict):
         width: Optional[int] = None,
         mask_type: Mask.Type = Type.POLYGON,
     ):
-        if mask_type != Mask.Type.POLYGON and (height is None or width is None):
+        if mask_type != Mask.Type.POLYGON and (
+            height is None or width is None
+        ):
             raise ValueError(
                 "Must provide height and width for RLE or Polygon type"
             )

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -517,9 +517,7 @@ class Mask(ToNumpy, ToDict):
         if mask_type != Mask.Type.POLYGON and (
             height is None or width is None
         ):
-            raise ValueError(
-                "Must provide height and width for RLE type"
-            )
+            raise ValueError("Must provide height and width for RLE type")
 
         self.type = mask_type
         self.data = data

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -514,7 +514,7 @@ class Mask(ToNumpy, ToDict):
         width: Optional[int] = None,
         mask_type: Mask.Type = Type.POLYGON,
     ):
-        if height is None or width is None:
+        if mask_type != Mask.Type.POLYGON and (height is None or width is None):
             raise ValueError(
                 "Must provide height and width for RLE or Polygon type"
             )
@@ -559,7 +559,7 @@ class Mask(ToNumpy, ToDict):
         )
 
     @staticmethod
-    def from_polygon(data: list[list[float]], height: int, width: int) -> Mask:
+    def from_polygon(data: list[list[float]]) -> Mask:
         """Build mask from a Polygon
 
         Parameters
@@ -572,9 +572,7 @@ class Mask(ToNumpy, ToDict):
         width: int
             The width of the image which the mask applies to.
         """
-        return Mask(
-            data, height=height, width=width, mask_type=Mask.Type.POLYGON
-        )
+        return Mask(data, mask_type=Mask.Type.POLYGON)
 
     @staticmethod
     def from_mask(mask: np.ndarray) -> Mask:

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -518,7 +518,7 @@ class Mask(ToNumpy, ToDict):
             height is None or width is None
         ):
             raise ValueError(
-                "Must provide height and width for RLE or Polygon type"
+                "Must provide height and width for RLE type"
             )
 
         self.type = mask_type
@@ -569,10 +569,6 @@ class Mask(ToNumpy, ToDict):
         data: list[list[float]]
             Multiple Polygon segmentation data. i.e.,
             ``[[x0, y0, x1, y1, ...], [x0, y0, x1, y1, ...]])``
-        height: int
-            The height of the image which the mask applies to.
-        width: int
-            The width of the image which the mask applies to.
         """
         return Mask(data, mask_type=Mask.Type.POLYGON)
 

--- a/src/main/scala/org/apache/spark/sql/rikai/Mask.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/Mask.scala
@@ -111,7 +111,7 @@ private[spark] class MaskType extends UserDefinedType[Mask] {
         maskType match {
           case MaskTypeEnum.Polygon =>
             Mask.fromPolygon(
-              row.getArray(3).toArray[Seq[Float]](ArrayType(FloatType)).toSeq,
+              row.getArray(3).toArray[Seq[Float]](ArrayType(FloatType)).toSeq
             )
           case MaskTypeEnum.Rle =>
             val height = row.getInt(1)


### PR DESCRIPTION
Height / width are irrelevant to polygon, and datasets like coco do not have height/width with the segmentations. 
