### PR TITLE
Use scala/scala-reflect 2.12.10

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        scala-version: [ 2.12.11, 2.13.7 ]
+        scala-version: [ 2.12.10, 2.13.7 ]
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -60,9 +60,13 @@ libraryDependencies ++= {
   val scalatestVersion = "3.2.0"
   val circeVersion = "0.12.3"
   val mlflowVersion = "1.21.0"
+  val enableifVersion = "1.1.7"
 
   Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
+    "com.thoughtworks.enableIf" %% "enableif" % enableifVersion exclude(
+      "org.scala-lang", "scala-reflect"
+    ),
     "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
     "software.amazon.awssdk" % "s3" % awsVersion % Provided,
     "org.xerial.snappy" % "snappy-java" % snappyVersion,
@@ -88,8 +92,6 @@ libraryDependencies ++= {
     )
   }
 }
-
-libraryDependencies += "com.thoughtworks.enableIf" %% "enableif" % "1.1.7"
 
 scalacOptions ++= Seq(
   "-encoding",

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import java.io.File
 import scala.reflect.io.Directory
 
-crossScalaVersions := List("2.12.11", "2.12.15", "2.13.7")
-scalaVersion := "2.12.11"
+crossScalaVersions := List("2.12.10", "2.12.15", "2.13.7")
+scalaVersion := "2.12.10"
 name := "rikai"
 
 def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
@@ -62,11 +62,14 @@ libraryDependencies ++= {
   val mlflowVersion = "1.21.0"
 
   Seq(
+    "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
     "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
     "software.amazon.awssdk" % "s3" % awsVersion % Provided,
     "org.xerial.snappy" % "snappy-java" % snappyVersion,
     "org.apache.logging.log4j" % "log4j-core" % log4jVersion % Runtime,
-    "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
+    "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion exclude(
+      "org.scala-lang", "scala-reflect"
+    ),
     "org.scalatest" %% "scalatest-funsuite" % scalatestVersion % Test,
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
Can not fix #415, but this PR is still valuable. As scala-library and scala-reflect are shipped by Apache Spark by default. We'd better exclude scala-reflect to avoid extra downloading and possible conflict.

(CI failed because of network error)

Align Scala library, scala-reflect version to what Apache Spark 3.1.2 ships by default.