### PR TITLE
Skip Scala 2.12.15 when publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,8 @@ inThisBuild(
         url("https://github.com/eto-ai/rikai")
       )
     ),
-    version := "0.0.16-SNAPSHOT",
+    version := dynverGitDescribeOutput.value
+      .mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value)),
     dynver := {
       val d = new java.util.Date
       sbtdynver.DynVer

--- a/build.sbt
+++ b/build.sbt
@@ -33,14 +33,14 @@ inThisBuild(
         url("https://github.com/eto-ai/rikai")
       )
     ),
-    version := dynverGitDescribeOutput.value
-      .mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value)),
+    version := "0.0.16-SNAPSHOT",
     dynver := {
       val d = new java.util.Date
       sbtdynver.DynVer
         .getGitDescribeOutput(d)
         .mkVersion(versionFmt, fallbackVersion(d))
-    }
+    },
+    skip.in(publish) := "2.12.15".equals(scalaVersion.value)
   )
 )
 


### PR DESCRIPTION
Fix #415 , needed to be tested by the publisher.