### PR TITLE
Tune image display on Databricks notebook again

### DIFF
--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -180,9 +180,7 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
                 inferred_format = Image(data).format
                 encoded = base64.b64encode(data).decode("utf-8")
                 url = f"data:image;base64,{encoded}"
-                return Image(
-                    url=url, embed=True, format=inferred_format, **kwargs
-                )
+                return Image(url=url, format=inferred_format)
 
     def draw(self, drawable: Union[Drawable, list[Drawable]]) -> Draw:
         return ImageDraw(self).draw(drawable)

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -35,20 +35,6 @@ def test_image() -> PILImage:
     return PILImage.fromarray(rescaled)
 
 
-def test_show_embedded_png(tmp_path, test_image):
-    uri = tmp_path / "test.png"
-    test_image.save(uri)
-    result = Image(uri)._repr_png_()
-    assert result is None
-
-
-def test_show_embedded_jpeg(tmp_path, test_image):
-    uri = tmp_path / "test.jpg"
-    test_image.save(uri)
-    result = Image(uri)._repr_jpeg_()
-    assert result is None
-
-
 def test_convert_to_embedded_image(tmp_path, test_image: PILImage):
     uri = tmp_path / "test.jpg"
     test_image.save(uri)

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -39,14 +39,14 @@ def test_show_embedded_png(tmp_path, test_image):
     uri = tmp_path / "test.png"
     test_image.save(uri)
     result = Image(uri)._repr_png_()
-    assert result == None
+    assert result is None
 
 
 def test_show_embedded_jpeg(tmp_path, test_image):
     uri = tmp_path / "test.jpg"
     test_image.save(uri)
     result = Image(uri)._repr_jpeg_()
-    assert result == None
+    assert result is None
 
 
 def test_convert_to_embedded_image(tmp_path, test_image: PILImage):

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -39,26 +39,14 @@ def test_show_embedded_png(tmp_path, test_image):
     uri = tmp_path / "test.png"
     test_image.save(uri)
     result = Image(uri)._repr_png_()
-    with open(uri, "rb") as fh:
-        expected = b2a_base64(fh.read()).decode("ascii")
-        assert result == expected
-
-        fh.seek(0)
-        embedded_image = Image(fh)
-        assert result == embedded_image._repr_png_()
+    assert result == None
 
 
 def test_show_embedded_jpeg(tmp_path, test_image):
     uri = tmp_path / "test.jpg"
     test_image.save(uri)
     result = Image(uri)._repr_jpeg_()
-    with open(uri, "rb") as fh:
-        expected = b2a_base64(fh.read()).decode("ascii")
-        assert result == expected
-
-        fh.seek(0)
-        embedded_image = Image(fh)
-        assert result == embedded_image._repr_jpeg_()
+    assert result == None
 
 
 def test_convert_to_embedded_image(tmp_path, test_image: PILImage):

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -38,7 +38,8 @@ def test_image() -> PILImage:
 
 def test_ipython_display(tmp_path, test_image: PILImage):
     # case 1: http uri
-    uri = "https://github.com/eto-ai/rikai/raw/main/python/tests/assets/test_image.jpg"
+    project = "https://github.com/eto-ai/rikai"
+    uri = f"{project}/raw/main/python/tests/assets/test_image.jpg"
     img1 = Image(uri)
     mimebundle1 = img1.display()._repr_mimebundle_()
     assert mimebundle1 == {"text/html": f'<img src="{uri}"/>'}


### PR DESCRIPTION
Fix #357 

+ [x] Tested on Databricks Notebook
+ [x] Tested on Jupyter Notebook

## Test Cases for Databricks Notebook
![image](https://user-images.githubusercontent.com/66561265/147720445-80c91f91-cc27-4d6b-a69e-45b55dd8170d.png)

![image](https://user-images.githubusercontent.com/66561265/147720477-861c565e-02c1-4019-80a2-be4e19ad060c.png)

![image](https://user-images.githubusercontent.com/66561265/147720489-376ff67c-6182-4a8b-b656-61321af04fa8.png)

## Test Cases for Jupyter Notebook

![image](https://user-images.githubusercontent.com/66561265/147720924-17ede2a8-e882-4ef2-994c-9278b1f0c4b6.png)

![image](https://user-images.githubusercontent.com/66561265/147721056-0ad7e051-147b-45d7-b12b-52b5654b9a12.png)


``` python
from rikai.types.vision import Image

Image("s3://bucket/darcy/image.png")
```
This case on local jupyter notebook does not work.
It is another issue that we need to fix later at https://github.com/eto-ai/rikai/issues/435.

