### PR TITLE
Use subprocess for mlflow

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -1,8 +1,0 @@
-version: "3.9"
-services:
-  mlflow:
-    build:
-      context: .
-      dockerfile: Dockerfile.mlflow
-    ports:
-      - 15000:5000

--- a/.github/workflows/bump-version-release.yml
+++ b/.github/workflows/bump-version-release.yml
@@ -38,33 +38,21 @@ jobs:
         java-version: 11
     - name: Run style check
       run: make lint
-    - name: Start docker-compose
-      run: |
-        docker-compose -f .github/docker-compose.yml up -d
-        sleep 10
     - name: Run Scala tests
       run: sbt test
       env:
         SPARK_LOCAL_IP: "127.0.0.1"
-        TEST_MLFLOW_TRACKING_URI: "http://localhost:15000"
-    - name: Stop docker-compose
-      run: docker-compose -f .github/docker-compose.yml down
     - name: Install jar for Python tests
       run: sbt publishLocal
     - name: Python lint
       working-directory: python
       run: pylint rikai || true
-    - name: Start docker-compose
-      run: |
-        docker-compose -f .github/docker-compose.yml up -d
-        sleep 10
     - name: Run python tests
       working-directory: python
       run: |
         pytest -v --durations=10 --ignore=tests/parquet/internal
       env:
         SPARK_LOCAL_IP: "127.0.0.1"
-        TEST_MLFLOW_TRACKING_URI: "http://localhost:15000"
     - name: Bump version and make tag
       run: make release
     - name: Push new version and tag
@@ -73,5 +61,3 @@ jobs:
         github_token: ${{ secrets.RELEASE_TOKEN }}
         branch: main
         tags: true
-    - name: Stop docker-compose
-      run: docker-compose -f .github/docker-compose.yml down

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -35,10 +35,6 @@ jobs:
     - name: sbt install
       run: |
         sbt publishLocal
-    - name: Start docker-compose
-      run: |
-        docker-compose -f .github/docker-compose.yml up -d
-        sleep 10
     - name: cache pip
       uses: actions/cache@v2
       with:
@@ -59,7 +55,6 @@ jobs:
         pytest -x -v --durations=10 --ignore=tests/parquet/internal
       env:
         SPARK_LOCAL_IP: "127.0.0.1"
-        TEST_MLFLOW_TRACKING_URI: "http://localhost:15000"
   mac-build:
     runs-on: macos-11
     timeout-minutes: 10

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -30,16 +30,9 @@ jobs:
       working-directory: python
       run: |
         python -m pip install -e .[pytorch]
-    - name: Start docker-compose
-      run: |
-        docker-compose -f .github/docker-compose.yml up -d
-        sleep 10
     - name: Run Scala tests
       run: sbt ++${{matrix.scala-version}} test
       env:
         SPARK_LOCAL_IP: "127.0.0.1"
-        TEST_MLFLOW_TRACKING_URI: "http://localhost:15000"
     - name: Build Scala Jar
       run: sbt package
-    - name: Stop docker-compose
-      run: docker-compose -f .github/docker-compose.yml down


### PR DESCRIPTION
This pr fix https://github.com/eto-ai/rikai/compare/use_subprocess_for_mlflow?expand=1
Should save time for about 1 min in every test workflow.