### PR TITLE
[GH] Improve GH actions timing

### DIFF
--- a/.github/workflows/bump-version-release.yml
+++ b/.github/workflows/bump-version-release.yml
@@ -18,6 +18,9 @@ jobs:
       run: |
         git config user.name 'Rikai Release'
         git config user.email 'rikai-dev@eto.ai'
+    - name: Start docker-compose
+      run: |
+        docker-compose -f .github/docker-compose.yml up -d
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
@@ -38,10 +41,6 @@ jobs:
         java-version: 11
     - name: Run style check
       run: make lint
-    - name: Start docker-compose
-      run: |
-        docker-compose -f .github/docker-compose.yml up -d
-        sleep 10
     - name: Run Scala tests
       run: sbt test
       env:
@@ -57,7 +56,7 @@ jobs:
     - name: Start docker-compose
       run: |
         docker-compose -f .github/docker-compose.yml up -d
-        sleep 10
+        sleep 5
     - name: Run python tests
       working-directory: python
       run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,7 +38,6 @@ jobs:
     - name: Start docker-compose
       run: |
         docker-compose -f .github/docker-compose.yml up -d
-        sleep 10
     - name: cache pip
       uses: actions/cache@v2
       with:
@@ -46,12 +45,13 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-
-    - name: Pip install
-      working-directory: python
+    - name: apt update and install
       run: |
         sudo apt update
         sudo apt-get -y -qq install libsnappy-dev ffmpeg
+    - name: Pip install
+      working-directory: python
+      run: |
         python -m pip install -e .[all,dev]
     - name: Run python tests
       working-directory: python

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         fetch-depth: 0
         lfs: true
+    - name: Start docker-compose
+      run: |
+        docker-compose -f .github/docker-compose.yml up -d
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
@@ -30,10 +33,6 @@ jobs:
       working-directory: python
       run: |
         python -m pip install -e .[pytorch]
-    - name: Start docker-compose
-      run: |
-        docker-compose -f .github/docker-compose.yml up -d
-        sleep 10
     - name: Run Scala tests
       run: sbt ++${{matrix.scala-version}} test
       env:


### PR DESCRIPTION
1. Separate apt from pip to see what's taking long
2. Reorder when docker-compose up is called to avoid having to sleep