### PR TITLE
use hosted toolcache to replace ~/.cache/pip

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -53,10 +53,12 @@ jobs:
     - name: Pip install
       working-directory: python
       run: |
+        PYTHONUSERBASE=/opt/hostedtoolcache/rikai/${{ matrix.python-version }} \
         python -m pip install --target=/opt/hostedtoolcache/rikai/${{ matrix.python-version }} -e .[all,dev]
     - name: Run python tests
       working-directory: python
       run: |
+        pip install pytest
         PYTHONUSERBASE=/opt/hostedtoolcache/rikai/${{ matrix.python-version }} pytest -x -v --durations=10 --ignore=tests/parquet/internal
       env:
         SPARK_LOCAL_IP: "127.0.0.1"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,7 +42,7 @@ jobs:
     - name: cache pip
       uses: actions/cache@v2
       with:
-        path: /opt/hostedtoolcache/Python/
+        path: /opt/hostedtoolcache/rikai/${{ matrix.python-version }}
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
@@ -53,11 +53,11 @@ jobs:
     - name: Pip install
       working-directory: python
       run: |
-        python -m pip install -e .[all,dev]
+        python -m pip install --target=/opt/hostedtoolcache/rikai/${{ matrix.python-version }} -e .[all,dev]
     - name: Run python tests
       working-directory: python
       run: |
-        pytest -x -v --durations=10 --ignore=tests/parquet/internal
+        PYTHONUSERBASE=/opt/hostedtoolcache/rikai/${{ matrix.python-version }} pytest -x -v --durations=10 --ignore=tests/parquet/internal
       env:
         SPARK_LOCAL_IP: "127.0.0.1"
         TEST_MLFLOW_TRACKING_URI: "http://localhost:15000"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -54,7 +54,7 @@ jobs:
       working-directory: python
       run: |
         PYTHONUSERBASE=/opt/hostedtoolcache/rikai/${{ matrix.python-version }} \
-        python -m pip install --target=/opt/hostedtoolcache/rikai/${{ matrix.python-version }} -e .[all,dev]
+        python -m pip install --user --target=/opt/hostedtoolcache/rikai/${{ matrix.python-version }} -e .[all,dev]
     - name: Run python tests
       working-directory: python
       run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /opt/hostedtoolcache/Python/
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: apt update and install

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -54,7 +54,7 @@ jobs:
       working-directory: python
       run: |
         PYTHONUSERBASE=/opt/hostedtoolcache/rikai/${{ matrix.python-version }} \
-        python -m pip install --user --target=/opt/hostedtoolcache/rikai/${{ matrix.python-version }} -e .[all,dev]
+        python -m pip install --user -e .[all,dev]
     - name: Run python tests
       working-directory: python
       run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,7 +42,7 @@ jobs:
     - name: cache pip
       uses: actions/cache@v2
       with:
-        path: ~/.cache/pip
+        path: /opt/hostedtoolcache/Python/
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /opt/hostedtoolcache/Python/
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: apt update and install


### PR DESCRIPTION
From the logs here: https://github.com/eto-ai/rikai/runs/4714645962?check_suite_focus=true#step:11:13
We can see not all pip packages will go through `~/.cache/pip`, but all pip packages will go through `/opt/hostedtoolcache/Python/`.