### PR TITLE
Prefix Rikai properties with `spark.`

### DIFF
--- a/contrib/yolov5/tests/test_yolov5.py
+++ b/contrib/yolov5/tests/test_yolov5.py
@@ -55,7 +55,7 @@ def test_yolov5(tmp_path: Path, spark: SparkSession):
             device = "cpu"
 
         spark.conf.set(
-            "rikai.sql.ml.registry.mlflow.tracking_uri", tracking_uri
+            "spark.rikai.sql.ml.registry.mlflow.tracking_uri", tracking_uri
         )
         work_dir = Path().absolute().parent.parent
         image_path = f"{work_dir}/python/tests/assets/test_image.jpg"

--- a/python/rikai/spark/sql/codegen/mlflow_logger.py
+++ b/python/rikai/spark/sql/codegen/mlflow_logger.py
@@ -17,7 +17,7 @@ Rikai SQL ML
 import warnings
 from typing import Any, Optional
 
-CONF_MLFLOW_TRACKING_URI = "rikai.sql.ml.registry.mlflow.tracking_uri"
+CONF_MLFLOW_TRACKING_URI = "spark.rikai.sql.ml.registry.mlflow.tracking_uri"
 CONF_MLFLOW_OUTPUT_SCHEMA = "rikai.output.schema"
 CONF_MLFLOW_SPEC_VERSION = "rikai.spec.version"
 CONF_MLFLOW_PRE_PROCESSING = "rikai.transforms.pre"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -145,7 +145,7 @@ def spark(mlflow_tracking_uri: str) -> SparkSession:
                 ),
                 ("spark.port.maxRetries", 128),
                 (
-                    "rikai.sql.ml.registry.test.impl",
+                    "spark.rikai.sql.ml.registry.test.impl",
                     "ai.eto.rikai.sql.model.testing.TestRegistry",
                 ),
                 (
@@ -169,11 +169,11 @@ def spark(mlflow_tracking_uri: str) -> SparkSession:
                 ("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem"),
                 ("spark.hadoop.fs.s3a.access.key", os.environ.get("AWS")),
                 (
-                    "rikai.sql.ml.registry.mlflow.tracking_uri",
+                    "spark.rikai.sql.ml.registry.mlflow.tracking_uri",
                     mlflow_tracking_uri,
                 ),
                 (
-                    "rikai.sql.ml.catalog.impl",
+                    "spark.rikai.sql.ml.catalog.impl",
                     "ai.eto.rikai.sql.model.SimpleCatalog",
                 ),
             ]

--- a/python/tests/spark/sql/codegen/conftest.py
+++ b/python/tests/spark/sql/codegen/conftest.py
@@ -127,11 +127,11 @@ def spark_with_mlflow(mlflow_client_http) -> SparkSession:
                     ),
                 ),
                 (
-                    "rikai.sql.ml.catalog.impl",
+                    "spark.rikai.sql.ml.catalog.impl",
                     "ai.eto.rikai.sql.model.mlflow.MlflowCatalog",
                 ),
                 (
-                    "rikai.sql.ml.registry.mlflow.tracking_uri",
+                    "spark.rikai.sql.ml.registry.mlflow.tracking_uri",
                     mlflow_tracking_uri,
                 ),
             ]

--- a/python/tests/spark/sql/codegen/test_sklearn_flavor.py
+++ b/python/tests/spark/sql/codegen/test_sklearn_flavor.py
@@ -48,7 +48,7 @@ def test_sklearn_linear_regression(tmp_path: Path, spark: SparkSession):
         )
 
         spark.conf.set(
-            "rikai.sql.ml.registry.mlflow.tracking_uri", tracking_uri
+            "spark.rikai.sql.ml.registry.mlflow.tracking_uri", tracking_uri
         )
         spark.sql(
             f"""
@@ -97,7 +97,7 @@ def test_sklearn_random_forest(tmp_path: Path, spark: SparkSession):
         )
 
         spark.conf.set(
-            "rikai.sql.ml.registry.mlflow.tracking_uri", tracking_uri
+            "spark.rikai.sql.ml.registry.mlflow.tracking_uri", tracking_uri
         )
         spark.sql(
             f"""

--- a/src/main/scala/ai/eto/rikai/sql/model/Catalog.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/Catalog.scala
@@ -54,7 +54,7 @@ trait Catalog {
 
 object Catalog extends LazyLogging {
 
-  val SQL_ML_CATALOG_IMPL_KEY = "rikai.sql.ml.catalog.impl"
+  val SQL_ML_CATALOG_IMPL_KEY = "spark.rikai.sql.ml.catalog.impl"
   val SQL_ML_CATALOG_IMPL_DEFAULT = "ai.eto.rikai.sql.model.SimpleCatalog"
 
   /** A Catalog for local testing. */

--- a/src/main/scala/ai/eto/rikai/sql/model/Registry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/Registry.scala
@@ -69,7 +69,7 @@ abstract class PyImplRegistry extends Registry with LazyLogging {
 
 private[rikai] object Registry {
 
-  val REGISTRY_IMPL_PREFIX = "rikai.sql.ml.registry."
+  val REGISTRY_IMPL_PREFIX = "spark.rikai.sql.ml.registry."
   val REGISTRY_IMPL_SUFFIX = ".impl"
 
   /** To provide convenience when using the CREATE MODEL command we allow the user to specify
@@ -78,14 +78,14 @@ private[rikai] object Registry {
     * when `registerAll` is called so there is no guarantee that changing the value of this
     * config after cluster startup will have any impact.
     */
-  val DEFAULT_URI_ROOT_KEY = "rikai.sql.ml.registry.uri.root"
+  val DEFAULT_URI_ROOT_KEY = "spark.rikai.sql.ml.registry.uri.root"
 
   /** Automatically configure registries for file:/ and mlflow:/ model uri's.
     */
   val DEFAULT_REGISTRIES = Map(
-    "rikai.sql.ml.registry.file.impl" -> "ai.eto.rikai.sql.model.fs.FileSystemRegistry",
-    "rikai.sql.ml.registry.mlflow.impl" -> "ai.eto.rikai.sql.model.mlflow.MlflowRegistry",
-    "rikai.sql.ml.registry.torchhub.impl" -> "ai.eto.rikai.sql.model.torchhub.TorchHubRegistry"
+    "spark.rikai.sql.ml.registry.file.impl" -> "ai.eto.rikai.sql.model.fs.FileSystemRegistry",
+    "spark.rikai.sql.ml.registry.mlflow.impl" -> "ai.eto.rikai.sql.model.mlflow.MlflowRegistry",
+    "spark.rikai.sql.ml.registry.torchhub.impl" -> "ai.eto.rikai.sql.model.torchhub.TorchHubRegistry"
   )
   private val logger = Logger.getLogger(Registry.getClass)
 

--- a/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
@@ -122,7 +122,7 @@ class MlflowCatalog(val conf: SparkConf) extends Catalog {
 
 object MlflowCatalog {
 
-  val TRACKING_URI_KEY = "rikai.sql.ml.registry.mlflow.tracking_uri"
+  val TRACKING_URI_KEY = "spark.rikai.sql.ml.registry.mlflow.tracking_uri"
 
   val ARTIFACT_PATH_KEY = "rikai.model.artifact_path"
   val MODEL_FLAVOR_KEY = "rikai.model.flavor"


### PR DESCRIPTION
Spark ignores non-spark properties at start-up. We need to be able to use a spark-conf file rather than rely on setting the conf at session construction time in the code all the time