### PR TITLE
Support sklearn PCA models

### DIFF
--- a/python/rikai/spark/sql/codegen/sklearn.py
+++ b/python/rikai/spark/sql/codegen/sklearn.py
@@ -38,13 +38,21 @@ def generate_udf(spec: "rikai.spark.sql.codegen.base.ModelSpec"):
     A Spark Pandas UDF.
     """
 
+    def predict(model, X):
+        if hasattr(model, "predict"):
+            return model.predict(X)
+        elif hasattr(model, "transform"):
+            return model.transform(X)
+        else:
+            raise RuntimeError("predict or transform is not available")
+
     def sklearn_inference_udf(
         iter: Iterator[pd.Series],
     ) -> Iterator[pd.Series]:
         model = spec.load_model()
         for series in list(iter):
             X = np.vstack(series.apply(_pickler.loads).to_numpy())
-            y = [_pickler.dumps(pred.tolist()) for pred in model.predict(X)]
+            y = [_pickler.dumps(pred.tolist()) for pred in predict(model, X)]
             yield pd.Series(y)
 
     return pandas_udf(sklearn_inference_udf, returnType=BinaryType())

--- a/python/tests/spark/sql/codegen/test_sklearn_flavor.py
+++ b/python/tests/spark/sql/codegen/test_sklearn_flavor.py
@@ -20,6 +20,7 @@ import pytest
 from pyspark.sql import Row, SparkSession
 from pyspark.sql.types import DoubleType, LongType, StructField, StructType
 from sklearn.datasets import make_classification
+from sklearn.decomposition import PCA
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LinearRegression
 
@@ -122,4 +123,40 @@ def test_sklearn_random_forest(tmp_path: Path, spark: SparkSession):
         assert (
             result.collect()
             == spark.createDataFrame([Row(pred=1), Row(pred=1)]).collect()
+        )
+
+
+def test_sklearn_pca(tmp_path: Path, spark: SparkSession):
+    X = np.array([[-1, -1], [-2, -1], [-3, -2], [1, 1], [2, 1], [3, 2]])
+    model = PCA(n_components=2)
+
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    tracking_uri = "sqlite:///" + str(tmp_path / "tracking.db")
+    mlflow.set_tracking_uri(tracking_uri)
+    with mlflow.start_run():
+        model.fit(X)
+        model_name = "sklearn_pca"
+        reg_model_name = model_name
+        rikai.mlflow.sklearn.log_model(
+            model,
+            "model",
+            schema="array<float>",
+            registered_model_name=reg_model_name,
+        )
+        spark.conf.set(
+            "spark.rikai.sql.ml.registry.mlflow.tracking_uri", tracking_uri
+        )
+        spark.sql(
+            f"""
+            CREATE MODEL {model_name} USING 'mlflow:///{reg_model_name}';
+            """
+        )
+        result = spark.sql(
+            f"""
+            select ML_PREDICT({model_name}, array(3, 2)) as pred
+            """
+        )
+        result.show(1, vertical=False, truncate=False)
+        assert (
+            pytest.approx(result.head().pred) == model.transform([[3, 2]])[0]
         )


### PR DESCRIPTION
closes #477 

## Why?
Because for sklearn models, there are two ways as far as I know to apply a model:
+ `model.predict(X)`
+ `model.transform(X)`