### PR TITLE
rikai.sql.ml.registry.torchhub.enabled defaults to false

### DIFF
--- a/contrib/yolov5/tests/conftest.py
+++ b/contrib/yolov5/tests/conftest.py
@@ -33,10 +33,7 @@ def spark() -> SparkSession:
                         ]
                     ),
                 ),
-                (
-                    "rikai.sql.ml.registry.torchhub.enabled",
-                    "true"
-                )
+                ("rikai.sql.ml.registry.torchhub.enabled", "true"),
             ]
         )
     )

--- a/contrib/yolov5/tests/conftest.py
+++ b/contrib/yolov5/tests/conftest.py
@@ -33,6 +33,10 @@ def spark() -> SparkSession:
                         ]
                     ),
                 ),
+                (
+                    "rikai.sql.ml.registry.torchhub.enabled",
+                    "true"
+                )
             ]
         )
     )

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -176,10 +176,7 @@ def spark(mlflow_tracking_uri: str) -> SparkSession:
                     "spark.rikai.sql.ml.catalog.impl",
                     "ai.eto.rikai.sql.model.SimpleCatalog",
                 ),
-                (
-                    "rikai.sql.ml.registry.torchhub.enabled",
-                    "true"
-                )
+                ("rikai.sql.ml.registry.torchhub.enabled", "true"),
             ]
         )
     )

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -176,6 +176,10 @@ def spark(mlflow_tracking_uri: str) -> SparkSession:
                     "spark.rikai.sql.ml.catalog.impl",
                     "ai.eto.rikai.sql.model.SimpleCatalog",
                 ),
+                (
+                    "rikai.sql.ml.registry.torchhub.enabled",
+                    "true"
+                )
             ]
         )
     )

--- a/src/main/scala/ai/eto/rikai/RikaiConf.scala
+++ b/src/main/scala/ai/eto/rikai/RikaiConf.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022 Rikai Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ai.eto.rikai
 
 import org.apache.spark.sql.internal.SQLConf

--- a/src/main/scala/ai/eto/rikai/RikaiConf.scala
+++ b/src/main/scala/ai/eto/rikai/RikaiConf.scala
@@ -1,0 +1,9 @@
+package ai.eto.rikai
+
+import org.apache.spark.sql.internal.SQLConf
+
+object RikaiConf {
+  val TORCHHUB_REG_ENABLED: Boolean = SQLConf.get
+    .getConfString("rikai.sql.ml.registry.torchhub.enabled", "false")
+    .toBoolean
+}

--- a/src/main/scala/ai/eto/rikai/sql/model/torchhub/TorchHubRegistry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/torchhub/TorchHubRegistry.scala
@@ -16,11 +16,25 @@
 
 package ai.eto.rikai.sql.model.torchhub
 
-import ai.eto.rikai.sql.model.PyImplRegistry
+import ai.eto.rikai.RikaiConf
+import ai.eto.rikai.sql.model.{Model, ModelNotFoundException, ModelSpec, PyImplRegistry}
+import org.apache.spark.sql.SparkSession
 
 /** TorchHub-based Model [[Registry]].
   */
 class TorchHubRegistry(val conf: Map[String, String]) extends PyImplRegistry {
+  override def resolve(session: SparkSession, spec: ModelSpec): Model = {
+    if (RikaiConf.TORCHHUB_REG_ENABLED) {
+      super.resolve(session, spec)
+    } else {
+      throw new ModelNotFoundException(message =
+        """
+          |TorchHub Registry is disabled by default for security concerns.
+          |Be cautious and set `rikai.sql.ml.registry.torchhub.enabled` to true
+          |only for personal usage or testing purpose.
+          |""".stripMargin)
+    }
+  }
 
   override def pyClass: String =
     "rikai.spark.sql.codegen.torchhub_registry.TorchHubRegistry"

--- a/src/main/scala/ai/eto/rikai/sql/model/torchhub/TorchHubRegistry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/torchhub/TorchHubRegistry.scala
@@ -17,7 +17,12 @@
 package ai.eto.rikai.sql.model.torchhub
 
 import ai.eto.rikai.RikaiConf
-import ai.eto.rikai.sql.model.{Model, ModelNotFoundException, ModelSpec, PyImplRegistry}
+import ai.eto.rikai.sql.model.{
+  Model,
+  ModelNotFoundException,
+  ModelSpec,
+  PyImplRegistry
+}
 import org.apache.spark.sql.SparkSession
 
 /** TorchHub-based Model [[Registry]].
@@ -27,8 +32,7 @@ class TorchHubRegistry(val conf: Map[String, String]) extends PyImplRegistry {
     if (RikaiConf.TORCHHUB_REG_ENABLED) {
       super.resolve(session, spec)
     } else {
-      throw new ModelNotFoundException(message =
-        """
+      throw new ModelNotFoundException(message = """
           |TorchHub Registry is disabled by default for security concerns.
           |Be cautious and set `rikai.sql.ml.registry.torchhub.enabled` to true
           |only for personal usage or testing purpose.


### PR DESCRIPTION
Disable TorchHub Registry by default to avoid security issues.

Here is the error message with torchhub registry disabled:
```
>                   raise Py4JJavaError(
                        "An error occurred while calling {0}{1}{2}.\n".
                        format(target_id, ".", name), value)
E                   py4j.protocol.Py4JJavaError: An error occurred while calling o57.sql.
E                   : ai.eto.rikai.sql.model.ModelNotFoundException:
E                   TorchHub Registery is disabled by default for security concerns.
E                   Be cautious and set `rikai.sql.ml.registry.torchhub.enabled` to true
E                   only for personal usage or testing purpose.
E
E                   	at ai.eto.rikai.sql.model.torchhub.TorchHubRegistry.resolve(TorchHubRegistry.scala:31)
E                   	at ai.eto.rikai.sql.model.Registry$.resolve(Registry.scala:194)
```