### PR TITLE
Fix loading models from MlflowCatalog

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Pip install
       working-directory: python
       run: |
-        python -m pip install -e .[pytorch]
+        python -m pip install -e .[pytorch,mlflow]
     - name: Run Scala tests
       run: sbt ++${{matrix.scala-version}} test
       env:

--- a/experimental/torchhub/tests/test_torchhub_registry.py
+++ b/experimental/torchhub/tests/test_torchhub_registry.py
@@ -19,8 +19,8 @@ from pyspark.sql import SparkSession
 
 from rikai.contrib.torch.detections import OUTPUT_SCHEMA
 
-
 version = f"v{torchvision.__version__.split('+', maxsplit=1)[0]}"
+
 
 def test_create_model(spark: SparkSession):
     # TODO: run ml_predict on resnet50

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -224,7 +224,8 @@ class MlflowRegistry(Registry):
 
     def get_options(self, spec, run):
         options = run.data.params
-        options.update(spec.get("options", {}))
+        if spec.get("options", {}):
+            options.update(spec.get("options"))
         return options
 
     def get_model_version(

--- a/src/main/scala/ai/eto/rikai/sql/model/Catalog.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/Catalog.scala
@@ -18,6 +18,7 @@ package ai.eto.rikai.sql.model
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
 
 /** Catalog for SQL ML.
   */
@@ -59,20 +60,20 @@ object Catalog extends LazyLogging {
 
   /** A Catalog for local testing. */
   private[rikai] def testing: SimpleCatalog = {
-    getOrCreate(new SparkConf()).asInstanceOf[SimpleCatalog]
+    getOrCreate(SparkSession.getDefaultSession.get).asInstanceOf[SimpleCatalog]
   }
 
   private var catalog: Option[Catalog] = None
 
-  def getOrCreate(conf: SparkConf): Catalog = {
+  def getOrCreate(session: SparkSession): Catalog = {
     val className =
-      conf.get(SQL_ML_CATALOG_IMPL_KEY, SQL_ML_CATALOG_IMPL_DEFAULT)
+      session.conf.get(SQL_ML_CATALOG_IMPL_KEY, SQL_ML_CATALOG_IMPL_DEFAULT)
     if (catalog.isEmpty || catalog.get.getClass.getName != className) {
       catalog = Some(
         Class
           .forName(className)
-          .getDeclaredConstructor(classOf[SparkConf])
-          .newInstance(conf)
+          .getDeclaredConstructor(classOf[SparkSession])
+          .newInstance(session)
           .asInstanceOf[Catalog]
       )
     }

--- a/src/main/scala/ai/eto/rikai/sql/model/Catalog.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/Catalog.scala
@@ -17,7 +17,6 @@
 package ai.eto.rikai.sql.model
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 
 /** Catalog for SQL ML.

--- a/src/main/scala/ai/eto/rikai/sql/model/SimpleCatalog.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/SimpleCatalog.scala
@@ -16,11 +16,11 @@
 
 package ai.eto.rikai.sql.model
 
-import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
 
 /** A Simple Catalog in memory. Used for local testing only.
   */
-class SimpleCatalog(conf: SparkConf) extends Catalog {
+class SimpleCatalog(session: SparkSession) extends Catalog {
 
   private var models: Map[String, Model] = Map.empty
 

--- a/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
@@ -93,7 +93,7 @@ class MlflowCatalog(session: SparkSession) extends Catalog {
     * @return the model
     */
   override def getModel(name: String): Option[Model] = {
-    mlflowClient.getModel(name).map { modelVersion =>
+    mlflowClient.getModel(name).map { _ =>
       // TODO: cache the SparkUDFModel in the current session memory.
       val uri = s"mlflow:/$name"
       val spec = ModelSpec(name = Some(name), uri = uri)

--- a/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
@@ -21,16 +21,24 @@ import ai.eto.rikai.sql.model.mlflow.MlflowCatalog.{
   MODEL_FLAVOR_KEY,
   TRACKING_URI_KEY
 }
-import ai.eto.rikai.sql.model.{Catalog, Model, SparkUDFModel}
-import org.apache.spark.SparkConf
+import ai.eto.rikai.sql.model.{
+  Catalog,
+  Model,
+  ModelSpec,
+  Registry,
+  SparkUDFModel
+}
+import org.apache.spark.sql.SparkSession
 
 import scala.collection.JavaConverters._
 
 /** Use MLflow as a persisted backend for Model Catalog
   */
-class MlflowCatalog(val conf: SparkConf) extends Catalog {
+class MlflowCatalog(session: SparkSession) extends Catalog {
 
-  private val mlflowClient = new MlflowClientExt(conf.get(TRACKING_URI_KEY))
+  private val mlflowClient = new MlflowClientExt(
+    session.conf.get(TRACKING_URI_KEY)
+  )
 
   /** Create a ML Model that can be used in SQL ML in the current database.
     */
@@ -39,12 +47,7 @@ class MlflowCatalog(val conf: SparkConf) extends Catalog {
       model.name,
       Map() ++ model.flavor.map(MODEL_FLAVOR_KEY -> _)
     )
-    new SparkUDFModel(
-      name,
-      s"mlflow://$name",
-      "<anonymous>",
-      model.flavor
-    )
+    getModel(name).get
   }
 
   /** Return a list of models available for all Sessions */
@@ -63,7 +66,7 @@ class MlflowCatalog(val conf: SparkConf) extends Catalog {
             Some(
               new SparkUDFModel(
                 name,
-                s"mlflow://$name",
+                s"mlflow:/$name",
                 "<anonymous>",
                 flavor
               )
@@ -91,15 +94,10 @@ class MlflowCatalog(val conf: SparkConf) extends Catalog {
     */
   override def getModel(name: String): Option[Model] = {
     mlflowClient.getModel(name).map { modelVersion =>
-      val tagsMap = modelVersion.getTagsList.asScala
-        .map(t => t.getKey -> t.getValue)
-        .toMap
-      new SparkUDFModel(
-        name,
-        s"mlflow://$name",
-        "<anonymous>",
-        tagsMap.get(MODEL_FLAVOR_KEY)
-      )
+      // TODO: cache the SparkUDFModel in the current session memory.
+      val uri = s"mlflow:/$name"
+      val spec = ModelSpec(name = Some(name), uri = uri)
+      Registry.resolve(session, spec)
     }
   }
 

--- a/src/main/scala/ai/eto/rikai/sql/spark/Python.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/Python.scala
@@ -59,5 +59,7 @@ object Python {
     }
   }
 
-  def run(command: Seq[String]): Unit = Process(Seq(Python.pythonExec) ++ command)!!
+  def run(command: Seq[String]): Unit = Process(
+    Seq(Python.pythonExec) ++ command
+  ) !!
 }

--- a/src/main/scala/ai/eto/rikai/sql/spark/Python.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/Python.scala
@@ -58,4 +58,6 @@ object Python {
       throw new RuntimeException(stderr.toString)
     }
   }
+
+  def run(command: Seq[String]): Unit = Process(Seq(Python.pythonExec) ++ command)!!
 }

--- a/src/main/scala/ai/eto/rikai/sql/spark/execution/ModelCommand.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/execution/ModelCommand.scala
@@ -36,7 +36,7 @@ trait ModelCommand extends RunnableCommand {
   ): LogicalPlan = this.asInstanceOf[LogicalPlan]
 
   def catalog(session: SparkSession): Catalog = {
-    val catalog = Catalog.getOrCreate(session.sparkContext.getConf)
+    val catalog = Catalog.getOrCreate(session)
     catalog
   }
 

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLAstBuilder.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiSparkSQLAstBuilder.scala
@@ -37,7 +37,7 @@ private[parser] class RikaiSparkSQLAstBuilder(session: SparkSession)
     extends SparkSqlAstBuilder {
 
   val catalog: Catalog =
-    Catalog.getOrCreate(session.sparkContext.getConf)
+    Catalog.getOrCreate(session)
 
   override def visitFunctionCall(ctx: FunctionCallContext): Expression =
     withOrigin(ctx) {

--- a/src/test/resources/create_models.py
+++ b/src/test/resources/create_models.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 
+"""Creating models to Mlflow for tests.
+
+"""
+
 import torch
 import argparse
 
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--mlflow-uri", required=True)
+    parser.add_argument("--run-id", required=True)
     args = parser.parse_args()
-    pass
+
 
 if __name__ == "__main__":
     main()

--- a/src/test/resources/create_models.py
+++ b/src/test/resources/create_models.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import torch
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    args = parser.parse_args()
+    pass
+
+if __name__ == "__main__":
+    main()

--- a/src/test/resources/create_models.py
+++ b/src/test/resources/create_models.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+#
+#  Copyright (c) 2022 Rikai Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 """Register models into Mlflow for scala tests."""
 

--- a/src/test/resources/create_models.py
+++ b/src/test/resources/create_models.py
@@ -1,11 +1,35 @@
 #!/usr/bin/env python3
 
-"""Creating models to Mlflow for tests.
+"""Register models into Mlflow for scala tests."""
 
-"""
-
-import torch
 import argparse
+
+import mlflow
+import torch
+import torchvision
+
+import rikai
+from rikai.contrib.torch.detections import OUTPUT_SCHEMA
+
+
+def register_torch_model(model: torch.nn.Module, name: str):
+    artifact_path = "model"
+    pre_processing = (
+        "rikai.contrib.torch.transforms."
+        "fasterrcnn_resnet50_fpn.pre_processing"
+    )
+    post_processing = (
+        "rikai.contrib.torch.transforms."
+        "fasterrcnn_resnet50_fpn.post_processing"
+    )
+    rikai.mlflow.pytorch.log_model(
+        model,
+        artifact_path,
+        OUTPUT_SCHEMA,
+        pre_processing,
+        post_processing,
+        registered_model_name=name,
+    )
 
 
 def main():
@@ -13,6 +37,19 @@ def main():
     parser.add_argument("--mlflow-uri", required=True)
     parser.add_argument("--run-id", required=True)
     args = parser.parse_args()
+
+    mlflow.set_tracking_uri(args.mlflow_uri)
+    with mlflow.start_run(run_id=args.run_id):
+        resnet = torchvision.models.detection.fasterrcnn_resnet50_fpn(
+            pretrained=True,
+            progress=False,
+        )
+        register_torch_model(resnet, "resnet")
+        ssd = torchvision.models.detection.ssd300_vgg16(
+            pretrained=True,
+            progress=False,
+        )
+        register_torch_model(ssd, "ssd")
 
 
 if __name__ == "__main__":

--- a/src/test/scala/ai/eto/rikai/sql/model/CatalogTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/model/CatalogTest.scala
@@ -16,14 +16,17 @@
 
 package ai.eto.rikai.sql.model
 
-import org.scalatest.BeforeAndAfterEach
+import ai.eto.rikai.SparkTestSession
 import org.scalatest.funsuite.AnyFunSuite
 
-class CatalogTest extends AnyFunSuite with BeforeAndAfterEach {
+class CatalogTest extends AnyFunSuite with SparkTestSession {
 
   val catalog = Catalog.testing
 
-  override def beforeEach(): Unit = catalog.clear()
+  override def beforeEach(): Unit = {
+    catalog.clear()
+    super.beforeEach()
+  }
 
   test("Test simple catalog") {
     assert(!catalog.modelExists("foo"))

--- a/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
@@ -132,5 +132,13 @@ class MlflowCatalogTest
         )
       )
     )
+    assert(
+      spark
+        .sql("""
+      SELECT * FROM (
+        SELECT size(ML_PREDICT(ssd, image)) as num_objects FROM images
+      ) WHERE num_objects > 0
+    """).count() == 2
+    )
   }
 }

--- a/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
@@ -30,6 +30,8 @@ class MlflowCatalogTest
     with SparkSessionWithMlflow
     with BeforeAndAfterEach {
 
+  import spark.implicits._
+
   var run: RunInfo = null
 
   override def beforeEach(): Unit = {
@@ -83,5 +85,13 @@ class MlflowCatalogTest
       )
     )
 
+    val modelsDf = spark.sql("SHOW MODELS")
+    assert(
+      modelsDf.exceptAll(Seq(
+        ("resnet", "pytorch", "mlflow://resnet", ""),
+        ("ssd", "pytorch", "mlflow://ssd", "")
+      ).toDF("name", "flavor", "uri", "options")).isEmpty
+    )
+    modelsDf.show()
   }
 }

--- a/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
@@ -73,6 +73,15 @@ class MlflowCatalogTest
 
   test("test running a model registered model") {
     val script = getClass.getResource("/create_models.py").getPath
-    Python.run(Seq(script))
+    Python.run(
+      Seq(
+        script,
+        "--mlflow-uri",
+        testMlflowTrackingUri,
+        "--run-id",
+        run.getRunId
+      )
+    )
+
   }
 }

--- a/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
@@ -18,6 +18,7 @@ package ai.eto.rikai.sql.model.mlflow
 
 import ai.eto.rikai.sql.model.mlflow.MlflowCatalog.ARTIFACT_PATH_KEY
 import ai.eto.rikai.sql.spark.Python
+import org.apache.spark.sql.rikai.Image
 import org.mlflow.api.proto.ModelRegistry.{CreateModelVersion, ModelVersionTag}
 import org.mlflow.api.proto.Service.RunInfo
 import org.scalatest.BeforeAndAfterEach
@@ -93,5 +94,17 @@ class MlflowCatalogTest
       ).toDF("name", "flavor", "uri", "options")).isEmpty
     )
     modelsDf.show()
+
+    spark
+      .createDataFrame(
+        Seq(
+          (1, new Image(getClass.getResource("/000000304150.jpg").getPath)),
+          (2, new Image(getClass.getResource("/000000419650.jpg").getPath))
+        )
+      )
+      .toDF("image_id", "image")
+      .createOrReplaceTempView("images")
+
+
   }
 }

--- a/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Rikai authors
+ * Copyright 2022 Rikai authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package ai.eto.rikai.sql.model.mlflow
 
 import ai.eto.rikai.sql.model.mlflow.MlflowCatalog.ARTIFACT_PATH_KEY
+import ai.eto.rikai.sql.spark.Python
 import org.mlflow.api.proto.ModelRegistry.{CreateModelVersion, ModelVersionTag}
 import org.mlflow.api.proto.Service.RunInfo
 import org.scalatest.BeforeAndAfterEach
@@ -68,5 +69,10 @@ class MlflowCatalogTest
 
     val models = spark.sql("SHOW MODELS")
     models.show()
+  }
+
+  test("test running a model registered model") {
+    val script = getClass.getResource("/create_models.py").getPath
+    Python.run(Seq(script))
   }
 }

--- a/src/test/scala/ai/eto/rikai/sql/spark/execution/DropModelCommandTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/execution/DropModelCommandTest.scala
@@ -31,7 +31,7 @@ class DropModelCommandTest extends AnyFunSuite with SparkTestSession {
 
   def getCatalog(session: SparkSession): SimpleCatalog =
     Catalog
-      .getOrCreate(session.sparkContext.getConf)
+      .getOrCreate(session)
       .asInstanceOf[SimpleCatalog]
 
   test("test drop one model") {


### PR DESCRIPTION
With this PR, Rikai supports to directly run `SELECT ML_PREDICT(model, image)` over an existing model from mlflow. 