### PR TITLE
Temporarily Disable CREATE MODEL on MlflowRegistry

### DIFF
--- a/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalogTest.scala
@@ -36,6 +36,19 @@ class MlflowCatalogTest
 
   var run: RunInfo = null
 
+  def createModels(): Unit = {
+    val script = getClass.getResource("/create_models.py").getPath
+    Python.run(
+      Seq(
+        script,
+        "--mlflow-uri",
+        testMlflowTrackingUri,
+        "--run-id",
+        run.getRunId
+      )
+    )
+  }
+
   override def beforeEach(): Unit = {
     run = mlflowClient.client.createRun()
     super.beforeEach()
@@ -76,16 +89,7 @@ class MlflowCatalogTest
   }
 
   test("test running a model registered model") {
-    val script = getClass.getResource("/create_models.py").getPath
-    Python.run(
-      Seq(
-        script,
-        "--mlflow-uri",
-        testMlflowTrackingUri,
-        "--run-id",
-        run.getRunId
-      )
-    )
+    createModels()
 
     val modelsDf = spark.sql("SHOW MODELS")
     assert(


### PR DESCRIPTION
We've discovered that the current implement of `CREATE MODEL` using `MlflowRegistry` does not register a valid / runnable model into Mlflow. Lets disable this functionality, and find a workable design for 0.2.