### PR TITLE
add relational functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 -   repo: local
     hooks:
       -   id: fixlint

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -31,7 +31,8 @@ from rikai.spark.types.geometry import (
     MaskType,
     PointType,
 )
-from rikai.types import Image, rle
+from rikai.types import rle
+from rikai.types.vision import Image
 
 __all__ = ["Point", "Box3d", "Box2d", "Mask"]
 

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -76,8 +76,6 @@ class Point(ToNumpy, ToDict):
 
 
 class RelativeBox2d(Drawable):
-    from rikai.types.vision import Image as RikaiImage
-
     def __init__(self, xmin: float, ymin: float, xmax: float, ymax: float):
         assert (
             0 <= xmin <= xmax
@@ -103,7 +101,7 @@ class RelativeBox2d(Drawable):
             self.ymax * canvas_height,
         )
 
-    def toBox2d(self, img: RikaiImage):
+    def toBox2d(self, img: "rikai.types.vision.RikaiImage"):
         canvas_width = img.width
         canvas_height = img.height
         return Box2d(

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -119,25 +119,6 @@ class RelativeBox2d(Drawable):
             )
 
 
-# def toBox2d(self, canvas_width, canvas_height):
-#     return Box2d(
-#         self.xmin * canvas_width,
-#         self.ymin * canvas_height,
-#         self.xmax * canvas_width,
-#         self.ymax * canvas_height,
-#     )
-#
-# def toBox2d(self, img: "rikai.types.vision.RikaiImage"):
-#     canvas_width = img.width()
-#     canvas_height = img.height()
-#     return Box2d(
-#         self.xmin * canvas_width,
-#         self.ymin * canvas_height,
-#         self.xmax * canvas_width,
-#         self.ymax * canvas_height,
-#     )
-
-
 class Box2d(ToNumpy, Sequence, ToDict, Drawable):
     """2-D Bounding Box, defined by ``(xmin, ymin, xmax, ymax)``
 

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -22,7 +22,7 @@ from numbers import Real
 from typing import Optional, Sequence, Tuple, Union
 
 import numpy as np
-from PIL import Image, ImageDraw
+from PIL import ImageDraw
 
 from rikai.mixin import Drawable, ToDict, ToNumpy
 from rikai.spark.types.geometry import (
@@ -31,7 +31,7 @@ from rikai.spark.types.geometry import (
     MaskType,
     PointType,
 )
-from rikai.types import rle
+from rikai.types import Image, rle
 
 __all__ = ["Point", "Box3d", "Box2d", "Mask"]
 
@@ -73,6 +73,43 @@ class Point(ToNumpy, ToDict):
 
     def to_dict(self) -> dict:
         return {"x": self.x, "y": self.y, "z": self.z}
+
+
+class RelativeBox2d(Drawable):
+    def __init__(self, xmin: float, ymin: float, xmax: float, ymax: float):
+        assert (
+            0 <= xmin <= xmax
+        ), f"xmin({xmin}) and xmax({xmax}) must satisfy 0 <= xmin <= xmax"
+        assert (
+            0 <= ymin <= ymax
+        ), f"ymin({ymin}) and ymax({ymax}) must satisfy 0 <= ymin <= ymax"
+        self.xmin = float(xmin)
+        self.ymin = float(ymin)
+        self.xmax = float(xmax)
+        self.ymax = float(ymax)
+
+    def _render(self, render: "rikai.viz.Renderer", **kwargs) -> None:
+        canvas_width = kwargs["canvas_width"]
+        canvas_height = kwargs["canvas_height"]
+        self.toBox2d(canvas_width, canvas_height)._render(render, **kwargs)
+
+    def toBox2d(self, canvas_width, canvas_height):
+        return Box2d(
+            self.xmin * canvas_width,
+            self.ymin * canvas_height,
+            self.xmax * canvas_width,
+            self.ymax * canvas_height,
+        )
+
+    def toBox2d(self, img: Image):
+        canvas_width = img.width
+        canvas_height = img.height
+        return Box2d(
+            self.xmin * canvas_width,
+            self.ymin * canvas_height,
+            self.xmax * canvas_width,
+            self.ymax * canvas_height,
+        )
 
 
 class Box2d(ToNumpy, Sequence, ToDict, Drawable):

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -32,7 +32,6 @@ from rikai.spark.types.geometry import (
     PointType,
 )
 from rikai.types import rle
-from rikai.types.vision import Image as RikaiImage
 
 __all__ = ["Point", "Box3d", "Box2d", "Mask"]
 
@@ -77,6 +76,8 @@ class Point(ToNumpy, ToDict):
 
 
 class RelativeBox2d(Drawable):
+    from rikai.types.vision import Image as RikaiImage
+
     def __init__(self, xmin: float, ymin: float, xmax: float, ymax: float):
         assert (
             0 <= xmin <= xmax

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -33,7 +33,7 @@ from rikai.spark.types.geometry import (
 )
 from rikai.types import rle
 
-__all__ = ["Point", "Box3d", "Box2d", "Mask"]
+__all__ = ["Point", "Box3d", "Box2d", "RelativeBox2d", "Mask"]
 
 
 class Point(ToNumpy, ToDict):
@@ -91,25 +91,51 @@ class RelativeBox2d(Drawable):
     def _render(self, render: "rikai.viz.Renderer", **kwargs) -> None:
         canvas_width = kwargs["canvas_width"]
         canvas_height = kwargs["canvas_height"]
-        self.toBox2d(canvas_width, canvas_height)._render(render, **kwargs)
+        self.toBox2d((canvas_width, canvas_height))._render(render, **kwargs)
 
-    def toBox2d(self, canvas_width, canvas_height):
-        return Box2d(
-            self.xmin * canvas_width,
-            self.ymin * canvas_height,
-            self.xmax * canvas_width,
-            self.ymax * canvas_height,
-        )
+    def toBox2d(
+        self, size: Union["rikai.types.vision.Image", Tuple[float, float]]
+    ):
+        if type(size).__name__ == "Image":  # Are there more decent ways?
+            canvas_width = size.width()
+            canvas_height = size.height()
+            return Box2d(
+                self.xmin * canvas_width,
+                self.ymin * canvas_height,
+                self.xmax * canvas_width,
+                self.ymax * canvas_height,
+            )
+        elif isinstance(size, Tuple):
+            (canvas_width, canvas_height) = size
+            return Box2d(
+                self.xmin * canvas_width,
+                self.ymin * canvas_height,
+                self.xmax * canvas_width,
+                self.ymax * canvas_height,
+            )
+        else:
+            raise TypeError(
+                "pass in a rikai.types.vision.RikaiImage or Tuple[float,float]"
+            )
 
-    def toBox2d(self, img: "rikai.types.vision.RikaiImage"):
-        canvas_width = img.width()
-        canvas_height = img.height()
-        return Box2d(
-            self.xmin * canvas_width,
-            self.ymin * canvas_height,
-            self.xmax * canvas_width,
-            self.ymax * canvas_height,
-        )
+
+# def toBox2d(self, canvas_width, canvas_height):
+#     return Box2d(
+#         self.xmin * canvas_width,
+#         self.ymin * canvas_height,
+#         self.xmax * canvas_width,
+#         self.ymax * canvas_height,
+#     )
+#
+# def toBox2d(self, img: "rikai.types.vision.RikaiImage"):
+#     canvas_width = img.width()
+#     canvas_height = img.height()
+#     return Box2d(
+#         self.xmin * canvas_width,
+#         self.ymin * canvas_height,
+#         self.xmax * canvas_width,
+#         self.ymax * canvas_height,
+#     )
 
 
 class Box2d(ToNumpy, Sequence, ToDict, Drawable):

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -102,8 +102,8 @@ class RelativeBox2d(Drawable):
         )
 
     def toBox2d(self, img: "rikai.types.vision.RikaiImage"):
-        canvas_width = img.width
-        canvas_height = img.height
+        canvas_width = img.width()
+        canvas_height = img.height()
         return Box2d(
             self.xmin * canvas_width,
             self.ymin * canvas_height,

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -22,7 +22,7 @@ from numbers import Real
 from typing import Optional, Sequence, Tuple, Union
 
 import numpy as np
-from PIL import ImageDraw
+from PIL import Image, ImageDraw
 
 from rikai.mixin import Drawable, ToDict, ToNumpy
 from rikai.spark.types.geometry import (
@@ -32,7 +32,7 @@ from rikai.spark.types.geometry import (
     PointType,
 )
 from rikai.types import rle
-from rikai.types.vision import Image
+from rikai.types.vision import Image as RikaiImage
 
 __all__ = ["Point", "Box3d", "Box2d", "Mask"]
 
@@ -102,7 +102,7 @@ class RelativeBox2d(Drawable):
             self.ymax * canvas_height,
         )
 
-    def toBox2d(self, img: Image):
+    def toBox2d(self, img: RikaiImage):
         canvas_width = img.width
         canvas_height = img.height
         return Box2d(

--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -185,8 +185,7 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
                 return Image(url=url, format=inferred_format)
 
     def draw(self, drawable: Union[Drawable, list[Drawable]]) -> Draw:
-        # TODO get height/width of image draw
-        return ImageDraw(self).draw(drawable, self.height, self.width)
+        return ImageDraw(self).draw(drawable)
 
     def __repr__(self) -> str:
         if self.is_embedded:
@@ -300,8 +299,11 @@ class ImageDraw(Draw):
 
         render = PILRenderer(self.img)
         for layer in self.layers:
-            # TODO add option
-            layer._render(render)
+            layer._render(
+                render,
+                canvas_width=self.canvas_width,
+                canvas_height=self.canvas_height,
+            )
         return Image.from_pil(render.image)
 
     def display(self, **kwargs) -> "IPython.display.Image":

--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -67,10 +67,16 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
             uri = image
         super().__init__(data=data, uri=uri)
 
-    def _init_size(self):
+    def _init_size(self, **kwargs):
+        if kwargs["width"] and kwargs["height"]:
+            self._width = kwargs["width"]
+            self._height = kwargs["height"]
+            return self
+
         (w, h) = self.to_pil().size
         self._width = w
         self._height = h
+        return self
 
     def width(self):
         if not self._width:
@@ -160,7 +166,7 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
         if uri is None:
             buf = BytesIO()
             img.save(buf, format=format, **kwargs)
-            return Image(buf.getvalue(), width, height)
+            return Image(buf.getvalue())._init_size(width=width, height=height)
 
         parsed = urlparse(normalize_uri(uri))
         if parsed.scheme == "file":
@@ -170,7 +176,7 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
                 img.save(fobj, format=format, **kwargs)
                 fobj.flush()
                 copy(fobj.name, uri)
-        return Image(uri, width, height)
+        return Image(uri)._init_size(width=width, height=height)
 
     def display(self, **kwargs):
         """

--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -73,18 +73,14 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
         self._height = h
 
     def width(self):
-        if self._width:
-            return self._width
-        else:
+        if not self._width:
             self._init_size()
-            return self._width
+        return self._width
 
     def height(self):
-        if self._height:
-            return self._height
-        else:
+        if not self._height:
             self._init_size()
-            return self._height
+        return self._height
 
     @classmethod
     def from_array(

--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -55,7 +55,10 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
     __UDT__ = ImageType()
 
     def __init__(
-        self, image: Union[bytes, bytearray, IOBase, str, Path], width, height
+        self,
+        image: Union[bytes, bytearray, IOBase, str, Path],
+        width=None,
+        height=None,
     ):
         data, uri = None, None
         if isinstance(image, IOBase):

--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -57,8 +57,6 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
     def __init__(
         self,
         image: Union[bytes, bytearray, IOBase, str, Path],
-        width=None,
-        height=None,
     ):
         data, uri = None, None
         if isinstance(image, IOBase):
@@ -67,26 +65,25 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
             data = image
         else:
             uri = image
-        self._width = width
-        self._height = height
         super().__init__(data=data, uri=uri)
+
+    def _init_size(self):
+        (w, h) = self.to_pil().size
+        self._width = w
+        self._height = h
 
     def width(self):
         if self._width:
             return self._width
         else:
-            (w, h) = self.to_pil().size
-            self._width = w
-            self._height = h
+            self._init_size()
             return self._width
 
     def height(self):
         if self._height:
             return self._height
         else:
-            (w, h) = self.to_pil().size
-            self._width = w
-            self._height = h
+            self._init_size()
             return self._height
 
     @classmethod

--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -67,9 +67,27 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
             data = image
         else:
             uri = image
-        self.width = width
-        self.height = height
+        self._width = width
+        self._height = height
         super().__init__(data=data, uri=uri)
+
+    def width(self):
+        if self._width:
+            return self._width
+        else:
+            (w, h) = self.to_pil().size
+            self._width = w
+            self._height = h
+            return self._width
+
+    def height(self):
+        if self._height:
+            return self._height
+        else:
+            (w, h) = self.to_pil().size
+            self._width = w
+            self._height = h
+            return self._height
 
     @classmethod
     def from_array(
@@ -293,8 +311,9 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
 
 class ImageDraw(Draw):
     def __init__(self, img: Image):
-        super().__init__(img.width, img.height)
         self.img = img.to_pil()
+        (width, height) = self.img.size
+        super().__init__(width, height)
 
     def to_image(self) -> Image:
         if not self.layers:

--- a/python/rikai/viz.py
+++ b/python/rikai/viz.py
@@ -72,8 +72,10 @@ class Style(Drawable):
 class Draw(Displayable, ABC):
     """Draw is a container that contain the elements for visualized lazily."""
 
-    def __init__(self):
+    def __init__(self, canvas_width, canvas_height):
         self.layers = []
+        self.canvas_width = canvas_width
+        self.canvas_height = canvas_height
 
     def __repr__(self):
         first_layer = self.layers[0] if self.layers else "N/A"
@@ -85,7 +87,12 @@ class Draw(Displayable, ABC):
             include=include, exclude=exclude
         )
 
-    def draw(self, layer: Union[Drawable, list[Drawable]]) -> Draw:
+    def draw(
+        self,
+        layer: Union[Drawable, list[Drawable]],
+        canvas_width,
+        canvas_height,
+    ) -> Draw:
         # layer can not be checked against typing.Sequence or typing.Iterable,
         # because many of the Drawables are iterables (i.e., Box2d).
         if isinstance(layer, Drawable):
@@ -98,7 +105,7 @@ class Draw(Displayable, ABC):
         return self
 
     def __or__(self, other: Union[Drawable, list[Drawable]]) -> Draw:
-        return self.draw(other)
+        return self.draw(other, self.canvas_width, self.canvas_height)
 
 
 class Renderer(ABC):

--- a/python/rikai/viz.py
+++ b/python/rikai/viz.py
@@ -140,7 +140,11 @@ class PILRenderer(Renderer):
         return self.img
 
     def rectangle(
-        self, xy, color: str = get_option(CONF_RIKAI_VIZ_COLOR), width: int = 1
+        self,
+        xy,
+        color: str = get_option(CONF_RIKAI_VIZ_COLOR),
+        width: int = 1,
+        **kwargs,
     ):
         self.draw.rectangle(xy, outline=color, width=width)
 

--- a/python/rikai/viz.py
+++ b/python/rikai/viz.py
@@ -153,6 +153,7 @@ class PILRenderer(Renderer):
         xy,
         color: str = get_option(CONF_RIKAI_VIZ_COLOR),
         fill: bool = True,
+        **kwargs,
     ):
         if fill:
             overlay = PILImage.new("RGBA", self.img.size, (255, 255, 255, 0))
@@ -168,7 +169,11 @@ class PILRenderer(Renderer):
             self.draw.polygon(xy=xy, outline=color)
 
     def text(
-        self, xy, text: str, color: str = get_option(CONF_RIKAI_VIZ_COLOR)
+        self,
+        xy,
+        text: str,
+        color: str = get_option(CONF_RIKAI_VIZ_COLOR),
+        **kwargs,
     ):
         self.draw.text(xy, text, fill=color)
 

--- a/python/rikai/viz.py
+++ b/python/rikai/viz.py
@@ -90,8 +90,6 @@ class Draw(Displayable, ABC):
     def draw(
         self,
         layer: Union[Drawable, list[Drawable]],
-        canvas_width,
-        canvas_height,
     ) -> Draw:
         # layer can not be checked against typing.Sequence or typing.Iterable,
         # because many of the Drawables are iterables (i.e., Box2d).
@@ -105,7 +103,7 @@ class Draw(Displayable, ABC):
         return self
 
     def __or__(self, other: Union[Drawable, list[Drawable]]) -> Draw:
-        return self.draw(other, self.canvas_width, self.canvas_height)
+        return self.draw(other)
 
 
 class Renderer(ABC):

--- a/python/tests/test_io.py
+++ b/python/tests/test_io.py
@@ -40,7 +40,7 @@ def test_open_https_uri():
 
 
 def test_image_use_https_uri():
-    img = Image(WIKIPEDIA)
+    img = Image(WIKIPEDIA, None, None)
 
     fobj = BytesIO(
         requests.get(WIKIPEDIA, headers={"User-agent": USER_AGENT}).content

--- a/python/tests/test_io.py
+++ b/python/tests/test_io.py
@@ -40,7 +40,7 @@ def test_open_https_uri():
 
 
 def test_image_use_https_uri():
-    img = Image(WIKIPEDIA, None, None)
+    img = Image(WIKIPEDIA)
 
     fobj = BytesIO(
         requests.get(WIKIPEDIA, headers={"User-agent": USER_AGENT}).content

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -14,7 +14,6 @@
 
 import base64
 import filecmp
-from binascii import b2a_base64
 from io import BytesIO
 from pathlib import Path
 from typing import Union
@@ -24,8 +23,7 @@ import pytest
 from PIL import Image as PILImage
 from PIL import ImageDraw as PILImageDraw
 
-from rikai.io import open_uri
-from rikai.types.geometry import Box2d
+from rikai.types.geometry import Box2d, RelativeBox2d
 from rikai.types.vision import Image, ImageDraw
 from rikai.viz import Style, Text
 
@@ -196,6 +194,26 @@ def test_draw_image():
     draw.rectangle((1.0, 2.0, 10.0, 12.0), outline="red")
     draw.rectangle((20, 20, 40, 40), outline="red")
     assert np.array_equal(pil_image.to_numpy(), expected)
+
+
+def test_relative_draw():
+    (canvas_w, canvas_h) = (100, 100)
+    data = np.random.randint(0, 255, size=(canvas_w, canvas_h), dtype=np.uint8)
+    img = Image.from_array(data)
+
+    (x1, y1, x2, y2) = (20, 20, 40, 40)
+    rel_box = RelativeBox2d(
+        x1 / canvas_w, y1 / canvas_h, x2 / canvas_w, y2 / canvas_h
+    )
+    box = Box2d(x1, y1, x2, y2)
+
+    assert rel_box.toBox2d((canvas_w, canvas_h)) == box
+    assert rel_box.toBox2d(img) == box
+
+    rel_pil = (img | rel_box).to_image()
+    pil = (img | box).to_image()
+
+    assert np.array_equal(rel_pil.to_numpy(), pil.to_numpy())
 
 
 def test_draw_styled_images():


### PR DESCRIPTION
This closes https://github.com/eto-ai/rikai/issues/488
This PR implemented a `RelativeBox2d` class with minimal function to help users use relative coordinate. 

Concerns to not add a field to Box2d:
* Fields in Box2d would be serialized to long-term storage. Currently, it has four fields, a 25% volume increment for this function might not be efficient.

Concerns to not implement a fully functional `RelativeBox2d`:
* If we implement all the corresponding methods in `Box2d` for `RelativeBox2d`, the logic would be very complex especially when we consider the interaction between `Box2d` and `RelativeBox2d`, like `Box2d.iou(RelativeBox2d)`, and UDT related kinds of stuff.
* Here we use `Box2d` as a first-class citizen and give convenient methods to help users convert relative coordinate to it with less pain.