### PR TITLE
Python Support for Spark 3.2.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
         working-directory: python
         run: |
           pip install --user -e .[dev]
+          cd ..
           make lint
       - name: Python lint
         working-directory: python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Make Lint
+        working-directory: python
         run: |
           pip install --user -e .[dev]
           make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: 3.9
       - name: Make Lint
         run: |
-          pip install isort black pylint pycodestyle flake8
+          pip install --user -e .[dev]
           make lint
       - name: Python lint
         working-directory: python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,6 +37,7 @@ jobs:
     - name: sbt install
       run: |
         echo "SPARK_VERSION=${{matrix.spark-version}}" >> $GITHUB_ENV
+        export SPARK_VERSION=${{matrix.spark-version}}
         sbt publishLocal
     - name: Start docker-compose
       run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /opt/hostedtoolcache/rikai/${{ matrix.python-version }}
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-pip-${{ matrix.spark-version }}-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: apt update and install

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+        spark-version: [3.1.2, 3.2.0]
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
@@ -35,6 +36,7 @@ jobs:
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
     - name: sbt install
       run: |
+        echo "SPARK_VERSION=${{matrix.spark-version}}" >> $GITHUB_ENV
         sbt publishLocal
     - name: Start docker-compose
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,13 @@
--   repo: local
+repos:
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1  # pick the isort version you'd like to use from https://github.com/pre-commit/mirrors-isort/releases
     hooks:
-      -   id: fixlint
-          name: fixlint
-          entry: make fix lint
-          language: system
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+      - id: black
+  - repo: https://github.com/softwaremill/scala-pre-commit-hooks
+    rev: v0.3.0
+    hooks:
+      - id: sbt-scalafmt

--- a/Makefile
+++ b/Makefile
@@ -36,15 +36,14 @@ python/rikai/spark/sql/generated/RikaiModelSchemaParser.py: src/main/antlr4/org/
 
 lint:
 	sbt scalafmtCheckAll
-	black -l 79 --check python contrib/
+	black --check python contrib experimental
 	pycodestyle python contrib/
 .PHONY: lint
 
 # Fix code style
 fix:
 	sbt scalafmtAll
-	isort python contrib experimental
-	black -l 79 python contrib experimental
+	black python contrib experimental
 .PHONY: fix
 
 # increment to the next released version and add a release tag

--- a/build.sbt
+++ b/build.sbt
@@ -52,8 +52,15 @@ scmInfo := Some(
 )
 
 libraryDependencies ++= {
-  val sparkVersion =
-    if (scalaVersion.value.compareTo("2.12.15") >= 0) "3.2.0" else "3.1.2"
+  val sparkVersion = {
+    sys.env.get("SPARK_VERSION") match {
+      case Some(sparkVersion) => sparkVersion
+      case None => if (scalaVersion.value.compareTo("2.12.15") >= 0) "3.2.0" else "3.1.2"
+    }
+  }
+  val log = sLog.value
+  log.warn(s"Compiling Rikai with Spark version ${sparkVersion}")
+
   val awsVersion = "2.15.69"
   val log4jVersion = "2.17.1"
   val scalaLoggingVersion = "3.9.4"
@@ -65,7 +72,7 @@ libraryDependencies ++= {
 
   Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
-    "com.thoughtworks.enableIf" %% "enableif" % enableifVersion exclude (
+    "com.thoughtworks.enableIf" %% "enableif" % enableifVersion exclude(
       "org.scala-lang", "scala-reflect"
     ),
     "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
@@ -75,7 +82,7 @@ libraryDependencies ++= {
     "software.amazon.awssdk" % "s3" % awsVersion % Provided,
     "org.xerial.snappy" % "snappy-java" % snappyVersion,
     "org.apache.logging.log4j" % "log4j-core" % log4jVersion % Runtime,
-    "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion exclude (
+    "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion exclude(
       "org.scala-lang", "scala-reflect"
     ),
     "org.scalatest" %% "scalatest-funsuite" % scalatestVersion % Test,

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 
 from setuptools import find_packages, setup
@@ -46,6 +47,10 @@ all = (
     + aws
 )
 
+if os.environ["SPARK_VERSION"]:
+    spark_version = os.environ["SPARK_VERSION"]
+else:
+    spark_version = "3.1.2"
 
 setup(
     name="rikai",
@@ -68,7 +73,7 @@ setup(
         "pandas",
         "Pillow",
         "pyarrow>=6.0",
-        "pyspark==3.1.2",
+        f"pyspark=={spark_version}",
         "pyyaml",
         "requests",
         "semver",

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,7 @@ with open(
 
 # extras
 dev = [
-    "black==21.11b1",
+    "black==22.1.0",
     "bump2version",
     "flake8",
     "isort",

--- a/python/setup.py
+++ b/python/setup.py
@@ -47,7 +47,7 @@ all = (
     + aws
 )
 
-if os.environ["SPARK_VERSION"]:
+if os.environ.get("SPARK_VERSION", None):
     spark_version = os.environ["SPARK_VERSION"]
 else:
     spark_version = "3.1.2"

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,7 +13,7 @@ with open(
 
 # extras
 dev = [
-    "black",
+    "black==21.11b1",
     "bump2version",
     "flake8",
     "isort",

--- a/src/main/scala/ai/eto/rikai/sql/spark/RikaiSparkSessionExtensions.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/RikaiSparkSessionExtensions.scala
@@ -73,16 +73,20 @@ private class MlPredictRule(val session: SparkSession)
     }
   }
 
-  @enableIf(
-    scala.util.Properties.versionNumberString.compareTo("2.12.15") >= 0
+  @enableIf(c =>
+    c.classPath.exists(
+      _.getPath.matches(".*spark-catalyst_2\\.\\d+-3\\.2\\..*")
+    )
   )
   private def getFuncName(f: UnresolvedFunction): String = {
     // After Spark 3.2
     f.nameParts.last
   }
 
-  @enableIf(
-    scala.util.Properties.versionNumberString.compareTo("2.12.15") < 0
+  @enableIf(c =>
+    c.classPath.exists(
+      _.getPath.matches(".*spark-catalyst_2\\.\\d+-3\\.1\\..*")
+    )
   )
   private def getFuncName(f: UnresolvedFunction): String = {
     f.name.funcName

--- a/src/main/scala/ai/eto/rikai/sql/spark/execution/ModelCommand.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/execution/ModelCommand.scala
@@ -20,17 +20,26 @@ import ai.eto.rikai.sql.model.Catalog
 import com.thoughtworks.enableIf
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.types.StringType
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
 trait ModelCommand extends RunnableCommand {
   override final def children: Seq[LogicalPlan] = Nil
 
-  @enableIf(scala.util.Properties.versionNumberString.compareTo("2.12.15") >= 0)
+  @enableIf(c =>
+    c.classPath.exists(
+      _.getPath.matches(".*spark-catalyst_2\\.\\d+-3\\.2\\..*")
+    )
+  )
   override final def mapChildren(f: LogicalPlan => LogicalPlan): LogicalPlan =
     this.asInstanceOf[LogicalPlan]
-  @enableIf(scala.util.Properties.versionNumberString.compareTo("2.12.15") >= 0)
+
+  @enableIf(c =>
+    c.classPath.exists(
+      _.getPath.matches(".*spark-catalyst_2\\.\\d+-3\\.2\\..*")
+    )
+  )
   override final def withNewChildrenInternal(
       newChildren: IndexedSeq[LogicalPlan]
   ): LogicalPlan = this.asInstanceOf[LogicalPlan]

--- a/src/main/scala/org/apache/spark/sql/rikai/expressions/Box2d.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/expressions/Box2d.scala
@@ -45,7 +45,11 @@ case class Area(child: Expression)
 
   override def prettyName: String = "area"
 
-  @enableIf(scala.util.Properties.versionNumberString.compareTo("2.12.15") >= 0)
+  @enableIf(c =>
+    c.classPath.exists(
+      _.getPath.matches(".*spark-catalyst_2\\.\\d+-3\\.2\\..*")
+    )
+  )
   override def withNewChildInternal(newChild: Expression): Expression =
     copy(child = newChild)
 }
@@ -70,7 +74,11 @@ case class IOU(leftBox: Expression, rightBox: Expression)
 
   override def prettyName: String = "iou"
 
-  @enableIf(scala.util.Properties.versionNumberString.compareTo("2.12.15") >= 0)
+  @enableIf(c =>
+    c.classPath.exists(
+      _.getPath.matches(".*spark-catalyst_2\\.\\d+-3\\.2\\..*")
+    )
+  )
   override def withNewChildrenInternal(
       newLeft: Expression,
       newRight: Expression


### PR DESCRIPTION
This patch closes https://github.com/eto-ai/rikai/issues/421

Pyspark only supports Scala 2.12, so this patch checks the Spark version to define macros, not assume Scala 2.12 will use Spark 3.1.x and Scala 2.13 will use Spark 3.2.x