### PR TITLE
Canonicalized the name of python types to lower cases

### DIFF
--- a/python/rikai/spark/types/geometry.py
+++ b/python/rikai/spark/types/geometry.py
@@ -113,7 +113,7 @@ class PointType(UserDefinedType):
         return Point(datum[0], datum[1], datum[2])
 
     def simpleString(self) -> str:
-        return "PointType"
+        return "point"
 
 
 class Box3dType(UserDefinedType):
@@ -151,7 +151,7 @@ class Box3dType(UserDefinedType):
         return Box3d(datum[0], datum[1], datum[2], datum[3], datum[4])
 
     def simpleString(self) -> str:
-        return "Box3dType"
+        return "box3d"
 
 
 class MaskType(UserDefinedType):
@@ -208,4 +208,4 @@ class MaskType(UserDefinedType):
             raise ValueError(f"Unrecognized mask type: {datum[0]}")
 
     def simpleString(self) -> str:
-        return "Mask"
+        return "mask"

--- a/python/rikai/spark/types/video.py
+++ b/python/rikai/spark/types/video.py
@@ -60,7 +60,7 @@ class VideoStreamType(UserDefinedType):
         return VideoStream(datum[0])
 
     def simpleString(self) -> str:
-        return "VideoStreamType"
+        return "videostream"
 
 
 class YouTubeVideoType(UserDefinedType):
@@ -101,7 +101,7 @@ class YouTubeVideoType(UserDefinedType):
         return YouTubeVideo(datum[0])
 
     def simpleString(self) -> str:
-        return "YouTubeVideoType"
+        return "youtubevideo"
 
 
 class SegmentType(UserDefinedType):
@@ -145,4 +145,4 @@ class SegmentType(UserDefinedType):
         return Segment(datum[0], datum[1])
 
     def simpleString(self) -> str:
-        return "SegmentType"
+        return "segment"

--- a/python/rikai/spark/types/vision.py
+++ b/python/rikai/spark/types/vision.py
@@ -61,4 +61,4 @@ class ImageType(UserDefinedType):
         return Image(datum[0] or datum[1])
 
     def simpleString(self) -> str:
-        return "ImageType"
+        return "image"


### PR DESCRIPTION
To make it consistent with Spark types, i.e., `int`, `array`, `struct`. 