### PR TITLE
TFHub Registry

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -37,3 +37,34 @@ jobs:
       - name: Test rikai-torchhub
         working-directory: experimental/torchhub
         run: pytest -s -o log_cli=true
+  tfhub:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: sbt install
+        run: |
+          sbt publishLocal
+      - name: Install Dependencies
+        working-directory: python
+        run: |
+          python -m pip install -q --use-feature=in-tree-build . wheel
+      - name: Install rikai-tfhub
+        working-directory: experimental/tfhub
+        run: |
+          python -m pip install --use-feature=in-tree-build .[dev]
+      - name: Test rikai-tfhub
+        working-directory: experimental/tfhub
+        run: pytest -s -o log_cli=true
+

--- a/experimental/tfhub/rikai/experimental/tfhub/__init__.py
+++ b/experimental/tfhub/rikai/experimental/tfhub/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) 2022 Rikai Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/experimental/tfhub/rikai/experimental/tfhub/tfhub_registry.py
+++ b/experimental/tfhub/rikai/experimental/tfhub/tfhub_registry.py
@@ -1,0 +1,76 @@
+#  Copyright (c) 2022 Rikai Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Any
+from urllib.parse import urlparse
+
+import tensorflow_hub as tfhub
+
+from rikai.internal.reflection import find_func, has_func
+from rikai.logging import logger
+from rikai.spark.sql.codegen.base import Registry, udf_from_spec
+from rikai.spark.sql.model import ModelSpec
+
+
+class TFHubModelSpec(ModelSpec):
+    def __init__(self, handle, raw_spec: ModelSpec):
+        spec = {
+            "version": "1.0",
+            "schema": raw_spec["schema"],
+            "model": {"flavor": raw_spec["flavor"], "uri": raw_spec["uri"]},
+            "transforms": {
+                "pre": raw_spec.get("preprocessor", None),
+                "post": raw_spec.get("postprocessor", None),
+            },
+        }
+
+        # remove none value of pre/post processing
+        if not spec["transforms"]["pre"]:
+            del spec["transforms"]["pre"]
+        if not spec["transforms"]["post"]:
+            del spec["transforms"]["post"]
+
+        # defaults to the `tensorflow` flavor
+        if not spec["model"]["flavor"]:
+            spec["model"]["flavor"] = "tensorflow"
+
+        self.handle = handle
+        super().__init__(spec=spec, validate=True)
+
+    def load_model(self) -> Any:
+        """Load the model artifact specified in this spec"""
+        return tfhub.load(self.handle)
+
+
+class TFHubRegistry(Registry):
+    """TFHub-based Model Registry"""
+
+    def __repr__(self):
+        return "TFHubRegistry"
+
+    def resolve(self, raw_spec: dict):
+        name = raw_spec["name"]
+        uri = raw_spec["uri"]
+        logger.info(f"Resolving model {name} from {uri}")
+        parsed = urlparse(uri)
+        if parsed.netloc:
+            raise ValueError(
+                "URI with 2 forward slashes is not supported, "
+                "try URI with 1 slash instead"
+            )
+        if parsed.scheme != "tfhub":
+            raise ValueError(f"Expect schema: tfhub, but got {parsed.scheme}")
+        handle = f"https://tfhub.dev{parsed.path}"
+        spec = TFHubModelSpec(handle, raw_spec)
+        return udf_from_spec(spec)

--- a/experimental/tfhub/setup.py
+++ b/experimental/tfhub/setup.py
@@ -1,0 +1,21 @@
+from setuptools import find_namespace_packages, setup
+
+setup(
+    name="rikai-tfhub",
+    version="0.0.1",
+    license="Apache License, Version 2.0",
+    author="Rikai authors",
+    author_email="rikai-dev@eto.ai",
+    url="https://github.com/eto-ai/rikai",
+    python_requires=">=3.7",
+    install_requires=["rikai>=0.1.1", "tensorflow>=2.5.0", "tensorflow_hub"],
+    extras_require={
+        "dev": [
+            "black",
+            "isort",
+            # for testing
+            "pytest",
+        ]
+    },
+    packages=find_namespace_packages(include=["rikai.*"]),
+)

--- a/experimental/tfhub/setup.py
+++ b/experimental/tfhub/setup.py
@@ -15,6 +15,7 @@ setup(
             "isort",
             # for testing
             "pytest",
+            "torch"
         ]
     },
     packages=find_namespace_packages(include=["rikai.*"]),

--- a/experimental/tfhub/setup.py
+++ b/experimental/tfhub/setup.py
@@ -15,7 +15,7 @@ setup(
             "isort",
             # for testing
             "pytest",
-            "torch"
+            "torch",
         ]
     },
     packages=find_namespace_packages(include=["rikai.*"]),

--- a/experimental/tfhub/tests/conftest.py
+++ b/experimental/tfhub/tests/conftest.py
@@ -1,0 +1,42 @@
+#  Copyright 2022 Rikai Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from pyspark.sql import SparkSession
+
+from rikai.spark.utils import get_default_jar_version, init_spark_session
+
+
+@pytest.fixture(scope="module")
+def spark() -> SparkSession:
+    rikai_version = get_default_jar_version(use_snapshot=True)
+
+    return init_spark_session(
+        dict(
+            [
+                (
+                    "spark.jars.packages",
+                    ",".join(
+                        [
+                            "ai.eto:rikai_2.12:{}".format(rikai_version),
+                        ]
+                    ),
+                ),
+                (
+                    "spark.rikai.sql.ml.registry.tfhub.impl",
+                    "ai.eto.rikai.sql.model.tfhub.TFHubRegistry",
+                ),
+            ]
+        )
+    )

--- a/experimental/tfhub/tests/test_tfhub.py
+++ b/experimental/tfhub/tests/test_tfhub.py
@@ -1,0 +1,42 @@
+#  Copyright 2022 Rikai Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from pathlib import Path
+
+from pyspark.sql import SparkSession
+
+from rikai.spark.functions import to_image
+from rikai.contrib.tensorflow.models.ssd import OUTPUT_SCHEMA
+
+
+def test_ssd(spark: SparkSession):
+    spark.udf.register("to_image", to_image)
+    work_dir = Path().absolute().parent.parent
+    image_path = f"{work_dir}/python/tests/assets/test_image.jpg"
+    spark.sql(
+        f"""
+        CREATE MODEL tfssd
+        PREPROCESSOR 'rikai.contrib.tensorflow.models.ssd.pre_processing'
+        POSTPROCESSOR 'rikai.contrib.tensorflow.models.ssd.post_processing'
+        OPTIONS (device="cpu", batch_size=32)
+        RETURNS {OUTPUT_SCHEMA}
+        USING "tfhub:///tensorflow/ssd_mobilenet_v2/2";
+        """
+    )
+    result = spark.sql(
+        f"""
+    select ML_PREDICT(tfssd, to_image('{image_path}')) as preds
+    """
+    )
+    assert result.count() == 1

--- a/experimental/torchhub/rikai/experimental/torchhub/torchhub_registry.py
+++ b/experimental/torchhub/rikai/experimental/torchhub/torchhub_registry.py
@@ -35,12 +35,11 @@ class TorchHubModelSpec(ModelSpec):
             },
         }
 
-        # remove none value of pre/post processing
         repo_proj = repo_or_dir.split(":")[0].replace("/", ".")
+
+        # fill in the convention or remove none value of pre/post processing
         pre_f = f"rikai.contrib.torchhub.{repo_proj}.{model}.pre_processing"
         post_f = f"rikai.contrib.torchhub.{repo_proj}.{model}.post_processing"
-        schema_f = f"rikai.contrib.torchhub.{repo_proj}.{model}.OUTPUT_SCHEMA"
-
         if not spec["transforms"]["pre"]:
             if has_func(pre_f):
                 spec["transforms"]["pre"] = pre_f
@@ -52,8 +51,11 @@ class TorchHubModelSpec(ModelSpec):
             else:
                 del spec["transforms"]["post"]
 
+        schema_f = f"rikai.contrib.torchhub.{repo_proj}.{model}.OUTPUT_SCHEMA"
         if not spec["schema"] and has_func(schema_f):
             spec["schema"] = find_func(schema_f)
+
+        # defaults to the `pytorch` flavor
         if not spec["model"]["flavor"]:
             spec["model"]["flavor"] = "pytorch"
 

--- a/src/main/scala/ai/eto/rikai/sql/model/tfhub/TFHubRegistry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/tfhub/TFHubRegistry.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Rikai Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.eto.rikai.sql.model.tfhub
+
+import ai.eto.rikai.sql.model.PyImplRegistry
+
+/** TFHub-based Model [[Registry]].
+  */
+class TFHubRegistry(val conf: Map[String, String]) extends PyImplRegistry {
+
+  override def pyClass: String =
+    "rikai.experimental.tfhub.tfhub_registry.TFHubRegistry"
+}

--- a/src/main/scala/ai/eto/rikai/sql/model/tfhub/package.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/tfhub/package.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 Rikai Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.eto.rikai.sql.model
+
+/** TFHub-based [[Model]]s.
+  */
+package object tfhub {}


### PR DESCRIPTION
close #381 

Demo sql using Tensorflow Hub
``` sql
CREATE MODEL tfssd
PREPROCESSOR 'rikai.contrib.tensorflow.models.ssd.pre_processing'
POSTPROCESSOR 'rikai.contrib.tensorflow.models.ssd.post_processing'
OPTIONS (device="cpu", batch_size=32)
RETURNS {OUTPUT_SCHEMA}
USING "tfhub:///tensorflow/ssd_mobilenet_v2/2";

select ML_PREDICT(tfssd, to_image('{image_path}')) as preds
```