### PR TITLE
Support Bootstrappable ModelType

### DIFF
--- a/python/rikai/pytorch/models/fasterrcnn_resnet50_fpn.py
+++ b/python/rikai/pytorch/models/fasterrcnn_resnet50_fpn.py
@@ -13,11 +13,18 @@
 #  limitations under the License.
 
 from .torchvision import ObjectDetectionModelType
+import torchvision
 
 __all__ = ["MODEL_TYPE"]
 
 
 class FasterRCNNModelType(ObjectDetectionModelType):
+    def bootstrappable(self) -> bool:
+        return True
+
+    def bootstrap(self):
+        return torchvision.models.detection.fasterrcnn_resnet50_fpn()
+
     def __init__(self):
         super().__init__("fasterrcnn_resnet50_fpn")
 

--- a/python/rikai/pytorch/models/ssd.py
+++ b/python/rikai/pytorch/models/ssd.py
@@ -13,11 +13,18 @@
 #  limitations under the License.
 
 from .torchvision import ObjectDetectionModelType
+import torchvision
 
 __all__ = ["MODEL_TYPE"]
 
 
 class SSDModelType(ObjectDetectionModelType):
+    def bootstrappable(self) -> bool:
+        return True
+
+    def bootstrap(self):
+        return torchvision.models.detection.ssd.ssd300_vgg16()
+
     def __init__(self):
         super().__init__("SSD")
 

--- a/python/rikai/spark/sql/codegen/bootstrap.py
+++ b/python/rikai/spark/sql/codegen/bootstrap.py
@@ -21,45 +21,22 @@ __all__ = ["BootstrapRegistry"]
 
 
 class BootstrapModelSpec(ModelSpec):
-    """Bootstraped Model Spec.
-
-    Parameters
-    ----------
-    options : Dict[str, Any], optional
-        Additionally options. If the same option exists in spec already,
-        it will be overridden.
-    validate : bool, default True.
-        Validate the spec during construction. Default ``True``.
-    """
-
     def __init__(
         self,
-        options: Optional[dict] = None,
+        raw_spec: "ModelSpec",
         validate: bool = True,
     ):
-        spec = self._load_spec_dict(options)
-        super().__init__(spec, validate=validate)
-
-    def _load_spec_dict(self, options: Optional[dict]) -> dict:
-        """Convert the Run into a ModelSpec
-
-        Parameters
-        ----------
-        options: dict, default None
-            Runtime options to be used by the model/transforms
-
-        Returns
-        -------
-        spec: Dict[str, Any]
-        """
         spec = {
-            "version": MlflowLogger._CURRENT_MODEL_SPEC_VERSION,
+            "version": "1.0",
+            "schema": raw_spec.get("schema", None),
+            "model": {
+                "flavor": raw_spec.get("flavor", None),
+                "type": raw_spec.get("modelType", None),
+            },
         }
-
-        if options is not None and len(options) > 0:
-            spec["options"] = options
-
-        return spec
+        if not spec["schema"]:
+            del spec["schema"]
+        super().__init__(spec, validate=validate)
 
     def load_model(self):
         raise RuntimeError("BootstrapModelSpec does not load model")
@@ -72,6 +49,5 @@ class BootstrapRegistry(Registry):
         return "BootstrapRegistry"
 
     def make_model_spec(self, raw_spec: dict):
-        options = raw_spec.get("options", {})
-        spec = BootstrapModelSpec(options=options)
+        spec = BootstrapModelSpec(raw_spec)
         return spec

--- a/python/rikai/spark/sql/codegen/bootstrap.py
+++ b/python/rikai/spark/sql/codegen/bootstrap.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from rikai.spark.sql.codegen.base import ModelSpec, Registry
-from rikai.spark.sql.codegen.mlflow_logger import MlflowLogger
+from rikai.spark.sql.exceptions import SpecError
 from rikai.spark.sql.model import BOOTSTRAPPED_SPEC_SCHEMA
 
 __all__ = ["BootstrapRegistry"]
@@ -38,7 +38,10 @@ class BootstrapModelSpec(ModelSpec):
         super().__init__(spec, validate=validate)
 
     def validate(self):
-        return super().validate(BOOTSTRAPPED_SPEC_SCHEMA)
+        super().validate(BOOTSTRAPPED_SPEC_SCHEMA)
+        if not self.model_type.bootstrappable():
+            msg = "ModelType must be bootstrappable if no URI is specified"
+            raise SpecError(msg)
 
     def load_model(self):
         raise RuntimeError("BootstrapModelSpec does not load model")

--- a/python/rikai/spark/sql/codegen/bootstrap.py
+++ b/python/rikai/spark/sql/codegen/bootstrap.py
@@ -12,10 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Optional
-
 from rikai.spark.sql.codegen.base import ModelSpec, Registry
 from rikai.spark.sql.codegen.mlflow_logger import MlflowLogger
+from rikai.spark.sql.model import BOOTSTRAPPED_SPEC_SCHEMA
 
 __all__ = ["BootstrapRegistry"]
 
@@ -37,6 +36,9 @@ class BootstrapModelSpec(ModelSpec):
         if not spec["schema"]:
             del spec["schema"]
         super().__init__(spec, validate=validate)
+
+    def validate(self):
+        return super().validate(BOOTSTRAPPED_SPEC_SCHEMA)
 
     def load_model(self):
         raise RuntimeError("BootstrapModelSpec does not load model")

--- a/python/rikai/spark/sql/codegen/bootstrap.py
+++ b/python/rikai/spark/sql/codegen/bootstrap.py
@@ -61,6 +61,9 @@ class BootstrapModelSpec(ModelSpec):
 
         return spec
 
+    def load_model(self):
+        raise RuntimeError("BootstrapModelSpec does not load model")
+
 
 class BootstrapRegistry(Registry):
     """Bootrapped Model Registry"""

--- a/python/rikai/spark/sql/codegen/bootstrap.py
+++ b/python/rikai/spark/sql/codegen/bootstrap.py
@@ -1,0 +1,74 @@
+#  Copyright 2022 Rikai Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Optional
+
+from rikai.spark.sql.codegen.base import ModelSpec, Registry
+from rikai.spark.sql.codegen.mlflow_logger import MlflowLogger
+
+__all__ = ["BootstrapRegistry"]
+
+
+class BootstrapModelSpec(ModelSpec):
+    """Bootstraped Model Spec.
+
+    Parameters
+    ----------
+    options : Dict[str, Any], optional
+        Additionally options. If the same option exists in spec already,
+        it will be overridden.
+    validate : bool, default True.
+        Validate the spec during construction. Default ``True``.
+    """
+
+    def __init__(
+        self,
+        options: Optional[dict] = None,
+        validate: bool = True,
+    ):
+        spec = self._load_spec_dict(options)
+        super().__init__(spec, validate=validate)
+
+    def _load_spec_dict(self, options: Optional[dict]) -> dict:
+        """Convert the Run into a ModelSpec
+
+        Parameters
+        ----------
+        options: dict, default None
+            Runtime options to be used by the model/transforms
+
+        Returns
+        -------
+        spec: Dict[str, Any]
+        """
+        spec = {
+            "version": MlflowLogger._CURRENT_MODEL_SPEC_VERSION,
+        }
+
+        if options is not None and len(options) > 0:
+            spec["options"] = options
+
+        return spec
+
+
+class BootstrapRegistry(Registry):
+    """Bootrapped Model Registry"""
+
+    def __repr__(self):
+        return "BootstrapRegistry"
+
+    def make_model_spec(self, raw_spec: dict):
+        options = raw_spec.get("options", {})
+        spec = BootstrapModelSpec(options=options)
+        return spec

--- a/python/rikai/spark/sql/model.py
+++ b/python/rikai/spark/sql/model.py
@@ -50,7 +50,6 @@ SPEC_PAYLOAD_SCHEMA = {
                 "flavor": {"type": "string"},
                 "model_type": {"type": "string"},
             },
-            "required": ["uri"],
         },
         "transforms": {
             "type": "object",
@@ -202,6 +201,14 @@ class ModelSpec(ABC):
 
 class ModelType(ABC):
     """Declare a Rikai-compatible Model Type."""
+
+    def bootstrappable(self) -> bool:
+        """Return if it is a bootstrappable model type"""
+        return False
+
+    def bootstrap(self) -> Any:
+        """Load the model without specification"""
+        return None
 
     @abstractmethod
     def load_model(self, spec: ModelSpec, **kwargs):

--- a/python/rikai/spark/sql/model.py
+++ b/python/rikai/spark/sql/model.py
@@ -49,7 +49,7 @@ def gen_schema_spec(required_cols):
                 "properties": {
                     "uri": {"type": "string"},
                     "flavor": {"type": "string"},
-                    "model_type": {"type": "string"},
+                    "type": {"type": "string"},
                 },
                 "required": required_cols,
             },
@@ -66,7 +66,7 @@ def gen_schema_spec(required_cols):
 
 
 SPEC_PAYLOAD_SCHEMA = gen_schema_spec(["uri"])
-BOOTSTRAPPED_SPEC_SCHEMA = gen_schema_spec(["flavor", "model_type"])
+BOOTSTRAPPED_SPEC_SCHEMA = gen_schema_spec(["flavor", "type"])
 
 
 def _identity(x):

--- a/python/tests/pytorch/models/test_ssd.py
+++ b/python/tests/pytorch/models/test_ssd.py
@@ -1,0 +1,25 @@
+#  Copyright (c) 2022 Rikai Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from pyspark.sql import SparkSession
+from rikai.spark.functions import init
+
+
+def test_ssd(spark: SparkSession):
+    init(spark)
+    name = "ssd_model"
+    spark.sql(f"CREATE MODEL {name} FLAVOR pytorch MODEL_TYPE ssd")
+    uri = "https://i.scdn.co/image/ab67616d0000b273466def3ce70d94dcacb13c8d"
+    df = spark.sql(f"select explode(ML_PREDICT(ssd_model, to_image('{uri}')))")
+    assert df.count() > 10

--- a/python/tests/spark/sql/codegen/test_bootstrap.py
+++ b/python/tests/spark/sql/codegen/test_bootstrap.py
@@ -13,6 +13,11 @@
 #  limitations under the License.
 
 from pyspark.sql import SparkSession
+import pytest
+import py4j
+
+from rikai.spark.functions import init
+
 from utils import check_ml_predict
 
 
@@ -24,3 +29,24 @@ def test_fasterrcnn_resnet50_fpn(spark: SparkSession):
             MODEL_TYPE fasterrcnn_resnet50_fpn"""
     )
     check_ml_predict(spark, name)
+
+
+def test_failure_create(spark: SparkSession):
+    with pytest.raises(
+        py4j.protocol.Py4JJavaError,
+        match=r".*ModelType must be bootstrappable if no URI is specified.*",
+    ):
+        spark.sql(
+            f"""CREATE MODEL ssd_score
+                FLAVOR pytorch
+                MODEL_TYPE ssd_class_scores"""
+        )
+
+    with pytest.raises(
+        py4j.protocol.Py4JJavaError,
+        match=r".*None is not of type 'string'.*",
+    ):
+        spark.sql(
+            f"""CREATE MODEL ssd_score
+                MODEL_TYPE ssd_class_scores"""
+        )

--- a/python/tests/spark/sql/codegen/test_bootstrap.py
+++ b/python/tests/spark/sql/codegen/test_bootstrap.py
@@ -1,0 +1,24 @@
+#  Copyright (c) 2022 Rikai Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from pyspark.sql import SparkSession
+from utils import check_ml_predict
+
+
+def test_fasterrcnn_resnet50_fpn(spark: SparkSession):
+    name = "frf_model"
+    spark.sql(
+        f"CREATE MODEL {name} FLAVOR pytorch MODEL_TYPE fasterrcnn_resnet50_fpn"
+    )
+    check_ml_predict(spark, name)

--- a/python/tests/spark/sql/codegen/test_bootstrap.py
+++ b/python/tests/spark/sql/codegen/test_bootstrap.py
@@ -19,6 +19,8 @@ from utils import check_ml_predict
 def test_fasterrcnn_resnet50_fpn(spark: SparkSession):
     name = "frf_model"
     spark.sql(
-        f"CREATE MODEL {name} FLAVOR pytorch MODEL_TYPE fasterrcnn_resnet50_fpn"
+        f"""CREATE MODEL {name}
+            FLAVOR pytorch
+            MODEL_TYPE fasterrcnn_resnet50_fpn"""
     )
     check_ml_predict(spark, name)

--- a/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
@@ -27,7 +27,7 @@ statement
       (POSTPROCESSOR postprocess=processorClause)?
       (OPTIONS optionList)?
       (RETURNS datatype=dataType)?
-      (USING uri=STRING)	                        # createModel
+      (USING uri=STRING)?	                        # createModel
     | (DESC | DESCRIBE) MODEL model=qualifiedName   # describeModel
     | SHOW MODELS                                   # showModels
     | DROP MODEL model=qualifiedName                # dropModel

--- a/src/main/scala/ai/eto/rikai/sql/model/ModelSpec.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/ModelSpec.scala
@@ -21,7 +21,7 @@ package ai.eto.rikai.sql.model
   */
 case class ModelSpec(
     name: Option[String],
-    uri: String,
+    uri: Option[String] = None,
     flavor: Option[String] = None,
     modelType: Option[String] = None,
     schema: Option[String] = None,

--- a/src/main/scala/ai/eto/rikai/sql/model/Registry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/Registry.scala
@@ -16,6 +16,7 @@
 
 package ai.eto.rikai.sql.model
 
+import ai.eto.rikai.sql.model.bootstrap.BootstrapRegistry
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.http.client.utils.URIUtils
 import org.apache.log4j.Logger
@@ -149,15 +150,20 @@ private[rikai] object Registry {
   }
 
   @throws[ModelResolveException]
-  private[model] def getRegistry(uri: String): Registry = {
-    val parsedNormalizedUri = normalize_uri(uri)
-    val scheme: String = parsedNormalizedUri.getScheme
-    registryMap.get(scheme) match {
-      case Some(registry) => registry
+  private[model] def getRegistry(uriOption: Option[String]): Registry = {
+    uriOption match {
+      case Some(uri) =>
+        val parsedNormalizedUri = normalize_uri(uri)
+        val scheme: String = parsedNormalizedUri.getScheme
+        registryMap.get(scheme) match {
+          case Some(registry) => registry
+          case None =>
+            throw new ModelResolveException(
+              s"Model registry scheme '${scheme}' is not supported"
+            )
+        }
       case None =>
-        throw new ModelResolveException(
-          s"Model registry scheme '${scheme}' is not supported"
-        )
+        BootstrapRegistry
     }
   }
 

--- a/src/main/scala/ai/eto/rikai/sql/model/bootstrap/BootstrapRegistry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/bootstrap/BootstrapRegistry.scala
@@ -1,0 +1,12 @@
+package ai.eto.rikai.sql.model.bootstrap
+
+import ai.eto.rikai.sql.model.PyImplRegistry
+import com.typesafe.scalalogging.LazyLogging
+
+/** BootstrapRegistry is used when no registry URI is specified
+  */
+object BootstrapRegistry extends PyImplRegistry with LazyLogging {
+
+  override def pyClass: String =
+    "rikai.spark.sql.codegen.bootstrap.BootstrapRegistry"
+}

--- a/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
@@ -76,7 +76,6 @@ class MlflowCatalog(session: SparkSession) extends Catalog {
           }
       }
       .collect { case Some(model) => model }
-      .toSeq
   }
 
   /** Check a model with the specified name exists.
@@ -107,7 +106,7 @@ class MlflowCatalog(session: SparkSession) extends Catalog {
         // TODO: cache the SparkUDFModel in the process. It might have multiple
         // SparkSessions exist.
         val uri = s"mlflow:/$name"
-        val spec = ModelSpec(name = Some(name), uri = uri)
+        val spec = ModelSpec(name = Some(name), uri = Some(uri))
         val model = Registry.resolve(session, spec)
         model
       }

--- a/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/mlflow/MlflowCatalog.scala
@@ -76,6 +76,7 @@ class MlflowCatalog(session: SparkSession) extends Catalog {
           }
       }
       .collect { case Some(model) => model }
+      .toSeq
   }
 
   /** Check a model with the specified name exists.

--- a/src/main/scala/ai/eto/rikai/sql/model/testing/TestRegistry.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/testing/TestRegistry.scala
@@ -49,7 +49,8 @@ class TestRegistry(conf: Map[String, String])
       session: SparkSession,
       spec: ModelSpec
   ): Model = {
-    val parsed = URI.create(spec.uri)
+    require(spec.uri.isDefined)
+    val parsed = URI.create(spec.uri.get)
     parsed.getScheme match {
       case this.schema => {
         val model_name: String = spec.name match {
@@ -60,10 +61,12 @@ class TestRegistry(conf: Map[String, String])
             ).getName
         }
         logger.info(s"Creating Spark UDF model: func=${model_name} ${spec}")
-        new SparkUDFModel(model_name, spec.uri, model_name, spec.flavor)
+        new SparkUDFModel(model_name, spec.uri.get, model_name, spec.flavor)
       }
       case _ =>
-        throw new ModelNotFoundException(s"Fake model ${spec.uri} not found")
+        throw new ModelNotFoundException(
+          s"Fake model ${spec.uri.get} not found"
+        )
     }
   }
 }

--- a/src/main/scala/ai/eto/rikai/sql/spark/RikaiSparkSessionExtensions.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/RikaiSparkSessionExtensions.scala
@@ -59,7 +59,7 @@ private class MlPredictRule(val session: SparkSession)
         val model =
           Registry.resolve(
             session,
-            ModelSpec(name = None, uri = arg.toString)
+            ModelSpec(name = None, uri = Some(arg.toString))
           )
         Some(model)
       }

--- a/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
@@ -43,23 +43,16 @@ case class CreateModelCommand(
 
   @throws[ModelResolveException]
   private[spark] def asSpec: ModelSpec =
-    uri match {
-      case Some(u) =>
-        ModelSpec(
-          name = Some(name),
-          uri = Some(Registry.normalize_uri(u).toString),
-          flavor = flavor,
-          modelType = modelType,
-          schema = returns,
-          preprocessor = preprocessor,
-          postprocessor = postprocessor,
-          options = Some(options)
-        )
-      case None =>
-        throw new ModelResolveException(
-          "Must provide URI to CREATE MODEL (for now)"
-        )
-    }
+    ModelSpec(
+      name = Some(name),
+      uri = uri.map(Registry.normalize_uri).map(_.toString),
+      flavor = flavor,
+      modelType = modelType,
+      schema = returns,
+      preprocessor = preprocessor,
+      postprocessor = postprocessor,
+      options = Some(options)
+    )
 
   @throws[ModelResolveException]
   override def run(spark: SparkSession): Seq[Row] = {

--- a/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/execution/CreateModelCommand.scala
@@ -47,7 +47,7 @@ case class CreateModelCommand(
       case Some(u) =>
         ModelSpec(
           name = Some(name),
-          uri = Registry.normalize_uri(u).toString,
+          uri = Some(Registry.normalize_uri(u).toString),
           flavor = flavor,
           modelType = modelType,
           schema = returns,

--- a/src/main/scala/org/apache/spark/sql/rikai/model/ModelResolver.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/model/ModelResolver.scala
@@ -135,7 +135,7 @@ object ModelResolver {
 
       new SparkUDFModel(
         spec.name.get,
-        spec.uri,
+        spec.uri.getOrElse(""),
         udfName,
         flavor = spec.flavor,
         preFuncName = Some(preUdfName),

--- a/src/test/scala/ai/eto/rikai/sql/model/RegistryTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/model/RegistryTest.scala
@@ -36,7 +36,7 @@ class RegistryTest extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("Resolve default uri") {
-    val registry = Registry.getRegistry("/tmp/foo/bar")
+    val registry = Registry.getRegistry(Some("/tmp/foo/bar"))
     assert(registry.isInstanceOf[TestRegistry])
     val uri = Registry.normalize_uri("/tmp/foo/bar")
     val expected = "test:/tmp/foo/bar"

--- a/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiExtAstSqlParserTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiExtAstSqlParserTest.scala
@@ -112,4 +112,13 @@ class RikaiExtAstSqlParserTest extends AnyFunSuite {
 
     assert(cmd == null)
   }
+
+  test("no uri") {
+    val cmd = parser.parsePlan(
+      """
+        |CREATE MODEL resnet18 MODEL_TYPE resnet""".stripMargin)
+      .asInstanceOf[CreateModelCommand]
+    assert(cmd.name === "resnet18")
+    assert(cmd.uri === None)
+  }
 }

--- a/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiExtAstSqlParserTest.scala
+++ b/src/test/scala/ai/eto/rikai/sql/spark/parser/RikaiExtAstSqlParserTest.scala
@@ -114,8 +114,8 @@ class RikaiExtAstSqlParserTest extends AnyFunSuite {
   }
 
   test("no uri") {
-    val cmd = parser.parsePlan(
-      """
+    val cmd = parser
+      .parsePlan("""
         |CREATE MODEL resnet18 MODEL_TYPE resnet""".stripMargin)
       .asInstanceOf[CreateModelCommand]
     assert(cmd.name === "resnet18")


### PR DESCRIPTION
## Main Feature
No need to depend on extra model registry
``` sql
-- before
CREATE MODEL ssd_model
MODEL_TYPE ssd
USING 'mlflow://ssd'

-- now
CREATE MODEL ssd_model FLAVOR pytorch MODEL_TYPE ssd
```

Just make your ModelType bootstrappable, and provide the bootstrap method to load the model.
``` python
+    def bootstrappable(self) -> bool:
+       return True
+
+    def bootstrap(self):
+        return torchvision.models.detection.fasterrcnn_resnet50_fpn()
```

## Extra Bennefits
For model service (eg. [AWS rekognition](https://aws.amazon.com/rekognition/)), we do not load a model, we just call the API and get the result.