### PR TITLE
Tensor dataset support2

### DIFF
--- a/experimental/tfhub/setup.py
+++ b/experimental/tfhub/setup.py
@@ -15,7 +15,6 @@ setup(
             "isort",
             # for testing
             "pytest",
-            # "torch",
         ]
     },
     packages=find_namespace_packages(include=["rikai.*"]),

--- a/experimental/tfhub/setup.py
+++ b/experimental/tfhub/setup.py
@@ -15,7 +15,7 @@ setup(
             "isort",
             # for testing
             "pytest",
-            "torch",
+            # "torch",
         ]
     },
     packages=find_namespace_packages(include=["rikai.*"]),

--- a/experimental/tfhub/tests/conftest.py
+++ b/experimental/tfhub/tests/conftest.py
@@ -15,14 +15,14 @@
 import pytest
 from pyspark.sql import SparkSession
 
+from rikai.spark.functions import to_image
 from rikai.spark.utils import get_default_jar_version, init_spark_session
 
 
 @pytest.fixture(scope="module")
 def spark() -> SparkSession:
     rikai_version = get_default_jar_version(use_snapshot=True)
-
-    return init_spark_session(
+    spark = init_spark_session(
         dict(
             [
                 (
@@ -40,3 +40,6 @@ def spark() -> SparkSession:
             ]
         )
     )
+    spark.udf.register("to_image", to_image)
+
+    return spark

--- a/experimental/tfhub/tests/test_tfhub.py
+++ b/experimental/tfhub/tests/test_tfhub.py
@@ -69,7 +69,6 @@ def test_ssd_model_type2():
 
 
 def test_ssd(spark: SparkSession):
-    spark.udf.register("to_image", to_image)
     spark.sql(
         f"""
         CREATE MODEL tfssd
@@ -87,7 +86,6 @@ def test_ssd(spark: SparkSession):
 
 
 def test_multi_pics_ssd(spark: SparkSession):
-    spark.udf.register("to_image2", to_image)
     spark.sql(
         f"""
         CREATE MODEL tfssd2
@@ -98,7 +96,7 @@ def test_multi_pics_ssd(spark: SparkSession):
     )
 
     spark.range(10).selectExpr(
-        "id as id", f"to_image2('{image_path}') as image"
+        "id as id", f"to_image('{image_path}') as image"
     ).createOrReplaceTempView("test_view")
 
     result = spark.sql(

--- a/experimental/tfhub/tests/test_tfhub.py
+++ b/experimental/tfhub/tests/test_tfhub.py
@@ -53,7 +53,7 @@ def test_ssd_model_type2():
             ]
         )
     ]
-    results_list = apply_model_spec(
+    results_iter = apply_model_spec(
         {
             "name": "tfssd",
             "uri": f"tfhub:///tensorflow/ssd_mobilenet_v2/2",
@@ -61,8 +61,10 @@ def test_ssd_model_type2():
         },
         inputs_list,
     )
-    assert len(results_list) == 1
-    series = results_list[0]
+
+    assert len(results_iter) == 1
+    series = results_iter[0]
+    assert series.shape[0] == 6
     assert len(series[0]) == 100
 
 

--- a/experimental/tfhub/tests/test_tfhub.py
+++ b/experimental/tfhub/tests/test_tfhub.py
@@ -73,10 +73,10 @@ def test_ssd(spark: SparkSession):
 
 
 def test_multi_pics_ssd(spark: SparkSession):
-    spark.udf.register("to_image", to_image)
+    spark.udf.register("to_image2", to_image)
     spark.sql(
         f"""
-        CREATE MODEL tfssd
+        CREATE MODEL tfssd2
         MODEL_TYPE ssd
         OPTIONS (device="cpu", batch_size=32)
         USING "tfhub:///tensorflow/ssd_mobilenet_v2/2";
@@ -84,12 +84,12 @@ def test_multi_pics_ssd(spark: SparkSession):
     )
 
     spark.range(10).selectExpr(
-        "id as id", f"to_image('{image_path}') as image"
+        "id as id", f"to_image2('{image_path}') as image"
     ).createOrReplaceTempView("test_view")
 
     result = spark.sql(
         f"""
-    select id, ML_PREDICT(tfssd, image) as preds from test_view
+    select id, ML_PREDICT(tfssd2, image) as preds from test_view
     """
     )
     result.show()

--- a/experimental/tfhub/tests/test_tfhub.py
+++ b/experimental/tfhub/tests/test_tfhub.py
@@ -39,9 +39,20 @@ def test_ssd_model_type():
     series = results_list[0]
     assert len(series[0]) == 100
 
+
 def test_ssd_model_type2():
-    inputs_list = [pd.Series(
-        [Image(image_path), Image(image_path), Image(image_path),Image(image_path), Image(image_path), Image(image_path)])]
+    inputs_list = [
+        pd.Series(
+            [
+                Image(image_path),
+                Image(image_path),
+                Image(image_path),
+                Image(image_path),
+                Image(image_path),
+                Image(image_path),
+            ]
+        )
+    ]
     results_list = apply_model_spec(
         {
             "name": "tfssd",
@@ -53,6 +64,7 @@ def test_ssd_model_type2():
     assert len(results_list) == 1
     series = results_list[0]
     assert len(series[0]) == 100
+
 
 def test_ssd(spark: SparkSession):
     spark.udf.register("to_image", to_image)

--- a/experimental/tfhub/tests/test_tfhub.py
+++ b/experimental/tfhub/tests/test_tfhub.py
@@ -23,14 +23,14 @@ from rikai.types.vision import Image
 
 work_dir = Path().absolute().parent.parent
 image_path = f"{work_dir}/python/tests/assets/test_image.jpg"
-
+from rikai.contrib.tfhub.tensorflow.ssd import TF_HUB_URL as SSD_HUB_URL
 
 def test_ssd_model_type():
     inputs_list = [pd.Series(Image(image_path))]
     results_list = apply_model_spec(
         {
             "name": "tfssd",
-            "uri": f"tfhub:///tensorflow/ssd_mobilenet_v2/2",
+            "uri": SSD_HUB_URL,
             "modelType": "ssd",
         },
         inputs_list,
@@ -56,7 +56,7 @@ def test_ssd_model_type2():
     results_iter = apply_model_spec(
         {
             "name": "tfssd",
-            "uri": f"tfhub:///tensorflow/ssd_mobilenet_v2/2",
+            "uri": SSD_HUB_URL,
             "modelType": "ssd",
         },
         inputs_list,
@@ -74,7 +74,7 @@ def test_ssd(spark: SparkSession):
         CREATE MODEL tfssd
         MODEL_TYPE ssd
         OPTIONS (device="cpu", batch_size=32)
-        USING "tfhub:///tensorflow/ssd_mobilenet_v2/2";
+        USING "{SSD_HUB_URL}";
         """
     )
     result = spark.sql(
@@ -91,7 +91,7 @@ def test_multi_pics_ssd(spark: SparkSession):
         CREATE MODEL tfssd2
         MODEL_TYPE ssd
         OPTIONS (device="cpu", batch_size=32)
-        USING "tfhub:///tensorflow/ssd_mobilenet_v2/2";
+        USING "{SSD_HUB_URL}";
         """
     )
 

--- a/experimental/tfhub/tests/test_tfhub.py
+++ b/experimental/tfhub/tests/test_tfhub.py
@@ -26,11 +26,9 @@ image_path = f"{work_dir}/python/tests/assets/test_image.jpg"
 
 
 def test_ssd_model_type():
-    # inputs_list = [pd.Series(
-    #     [Image(image_path), Image(image_path), Image(image_path), Image(image_path), Image(image_path),
-    #      Image(image_path), Image(image_path), Image(image_path), Image(image_path), Image(image_path),
-    #      Image(image_path), Image(image_path)])]
-    inputs_list = [pd.Series(Image(image_path))]
+    inputs_list = [pd.Series(
+        [Image(image_path), Image(image_path), Image(image_path)])]
+    # inputs_list = [pd.Series(Image(image_path))]
     results_list = apply_model_spec(
         {
             "name": "tfssd",

--- a/experimental/tfhub/tests/test_tfhub.py
+++ b/experimental/tfhub/tests/test_tfhub.py
@@ -25,6 +25,7 @@ work_dir = Path().absolute().parent.parent
 image_path = f"{work_dir}/python/tests/assets/test_image.jpg"
 from rikai.contrib.tfhub.tensorflow.ssd import TF_HUB_URL as SSD_HUB_URL
 
+
 def test_ssd_model_type():
     inputs_list = [pd.Series(Image(image_path))]
     results_list = apply_model_spec(

--- a/experimental/tfhub/tests/test_tfhub.py
+++ b/experimental/tfhub/tests/test_tfhub.py
@@ -26,9 +26,7 @@ image_path = f"{work_dir}/python/tests/assets/test_image.jpg"
 
 
 def test_ssd_model_type():
-    inputs_list = [pd.Series(
-        [Image(image_path), Image(image_path), Image(image_path)])]
-    # inputs_list = [pd.Series(Image(image_path))]
+    inputs_list = [pd.Series(Image(image_path))]
     results_list = apply_model_spec(
         {
             "name": "tfssd",
@@ -41,6 +39,20 @@ def test_ssd_model_type():
     series = results_list[0]
     assert len(series[0]) == 100
 
+def test_ssd_model_type2():
+    inputs_list = [pd.Series(
+        [Image(image_path), Image(image_path), Image(image_path),Image(image_path), Image(image_path), Image(image_path)])]
+    results_list = apply_model_spec(
+        {
+            "name": "tfssd",
+            "uri": f"tfhub:///tensorflow/ssd_mobilenet_v2/2",
+            "modelType": "ssd",
+        },
+        inputs_list,
+    )
+    assert len(results_list) == 1
+    series = results_list[0]
+    assert len(series[0]) == 100
 
 def test_ssd(spark: SparkSession):
     spark.udf.register("to_image", to_image)

--- a/python/rikai/contrib/tfhub/tensorflow/ssd.py
+++ b/python/rikai/contrib/tfhub/tensorflow/ssd.py
@@ -37,7 +37,6 @@ class SSDModelType(TensorflowModelType):
         return None
 
     def predict(self, images, *args, **kwargs) -> Any:
-        print("images shape", images.shape)
         # one image should have shape (height,width,3),
         # multiple image should have shape (number,height,width,3)
         assert len(images.shape) == 4

--- a/python/rikai/contrib/tfhub/tensorflow/ssd.py
+++ b/python/rikai/contrib/tfhub/tensorflow/ssd.py
@@ -37,7 +37,8 @@ class SSDModelType(TensorflowModelType):
 
     def predict(self, images, *args, **kwargs) -> Any:
         print("images shape", images.shape)
-        # one image should have shape (height,width,3), multiple image should have shape (number,height,width,3)
+        # one image should have shape (height,width,3),
+        # multiple image should have shape (number,height,width,3)
         assert len(images.shape) == 4
         assert (
             self.model is not None

--- a/python/rikai/contrib/tfhub/tensorflow/ssd.py
+++ b/python/rikai/contrib/tfhub/tensorflow/ssd.py
@@ -40,7 +40,7 @@ class SSDModelType(TensorflowModelType):
         # one image should have shape (height,width,3), multiple image should have shape (number,height,width,3)
         assert len(images.shape) == 4
         assert (
-                self.model is not None
+            self.model is not None
         ), "model has not been initialized via load_model"
         results = []
         for image in images:
@@ -48,9 +48,9 @@ class SSDModelType(TensorflowModelType):
             batch = self.model([image])
 
             for boxes, classes, scores in zip(
-                    batch["detection_boxes"].numpy(),
-                    batch["detection_classes"].numpy(),
-                    batch["detection_scores"].numpy(),
+                batch["detection_boxes"].numpy(),
+                batch["detection_classes"].numpy(),
+                batch["detection_scores"].numpy(),
             ):
                 predict_result = []
                 for box, label_class, score in zip(boxes, classes, scores):

--- a/python/rikai/contrib/tfhub/tensorflow/ssd.py
+++ b/python/rikai/contrib/tfhub/tensorflow/ssd.py
@@ -13,15 +13,11 @@
 #  limitations under the License.
 
 """SSD: Single Shot MultiBox Detector
-
 https://arxiv.org/abs/1512.02325
 """
 
 
 from typing import Any, Callable, Dict
-
-import numpy
-from tensorflow.python.framework.ops import EagerTensor
 
 from rikai.tensorflow.models import TensorflowModelType
 from rikai.types.geometry import Box2d
@@ -39,37 +35,30 @@ class SSDModelType(TensorflowModelType):
     def transform(self) -> Callable:
         return None
 
-    def predict(self, images, *args, **kwargs) -> Any:
-        images = numpy.array([images[0]])
-        print("images_type:", type(images))
-        print("images_shape:", images.shape)
-        print("images_shape_len:", len(images.shape))
-        # df shape shape (12,)
-        # images_shape: (1, 5, 1028, 1024, 3)
-        # images_shape: (1, 1028, 1024, 3)
+    def predict(self, image, *args, **kwargs) -> Any:
+        print("ssd images shape", image.shape)
         assert (
-            self.model is not None
+                self.model is not None
         ), "model has not been initialized via load_model"
-        results = []
-        for image in images:
-            # TODO can't explain why image should be in a fixed length array
-            batch = self.model([image])
+        # a image have the shape (x,x,3), but, input needs (1,x,x,3)
+        batch = self.model([image])
 
-            for boxes, classes, scores in zip(
+        results = []
+        for boxes, classes, scores in zip(
                 batch["detection_boxes"].numpy(),
                 batch["detection_classes"].numpy(),
                 batch["detection_scores"].numpy(),
-            ):
-                predict_result = []
-                for box, label_class, score in zip(boxes, classes, scores):
-                    predict_result.append(
-                        {
-                            "detection_boxes": Box2d(*box),
-                            "detection_classes": int(label_class),
-                            "detection_scores": float(score),
-                        }
-                    )
-                results.append(predict_result)
+        ):
+            predict_result = []
+            for box, label_class, score in zip(boxes, classes, scores):
+                predict_result.append(
+                    {
+                        "detection_boxes": Box2d(*box),
+                        "detection_classes": int(label_class),
+                        "detection_scores": float(score),
+                    }
+                )
+            results.append(predict_result)
         return results
 
 

--- a/python/rikai/contrib/tfhub/tensorflow/ssd.py
+++ b/python/rikai/contrib/tfhub/tensorflow/ssd.py
@@ -23,6 +23,7 @@ from rikai.tensorflow.models import TensorflowModelType
 from rikai.types.geometry import Box2d
 
 HUB_URL = "https://tfhub.dev/tensorflow/ssd_mobilenet_v2/2"
+TF_HUB_URL = "tfhub:///tensorflow/ssd_mobilenet_v2/2"
 
 
 class SSDModelType(TensorflowModelType):
@@ -46,6 +47,9 @@ class SSDModelType(TensorflowModelType):
         results = []
         for image in images:
             # one image have the shape (x,x,3), but, input needs (1,x,x,3)
+            # get more details from the doc here
+            # https://tfhub.dev/tensorflow/ssd_mobilenet_v2/2
+
             batch = self.model([image])
 
             for boxes, classes, scores in zip(

--- a/python/rikai/contrib/tfhub/tensorflow/ssd.py
+++ b/python/rikai/contrib/tfhub/tensorflow/ssd.py
@@ -20,6 +20,8 @@ https://arxiv.org/abs/1512.02325
 
 from typing import Any, Callable, Dict
 
+from tensorflow.python.framework.ops import EagerTensor
+
 from rikai.tensorflow.models import TensorflowModelType
 from rikai.types.geometry import Box2d
 
@@ -36,7 +38,12 @@ class SSDModelType(TensorflowModelType):
     def transform(self) -> Callable:
         return None
 
-    def predict(self, images, *args, **kwargs) -> Any:
+    def predict(self, images: EagerTensor, *args, **kwargs) -> Any:
+        print("images_type:", type(images))
+        print("images_shape:", images.shape)
+        # df shape shape (12,)
+        # images_shape: (1, 5, 1028, 1024, 3)
+        # images_shape: (1, 1028, 1024, 3)
         assert (
             self.model is not None
         ), "model has not been initialized via load_model"

--- a/python/rikai/contrib/tfhub/tensorflow/ssd.py
+++ b/python/rikai/contrib/tfhub/tensorflow/ssd.py
@@ -35,30 +35,33 @@ class SSDModelType(TensorflowModelType):
     def transform(self) -> Callable:
         return None
 
-    def predict(self, image, *args, **kwargs) -> Any:
-        print("ssd images shape", image.shape)
+    def predict(self, images, *args, **kwargs) -> Any:
+        print("images shape", images.shape)
+        # one image should have shape (height,width,3), multiple image should have shape (number,height,width,3)
+        assert len(images.shape) == 4
         assert (
                 self.model is not None
         ), "model has not been initialized via load_model"
-        # a image have the shape (x,x,3), but, input needs (1,x,x,3)
-        batch = self.model([image])
-
         results = []
-        for boxes, classes, scores in zip(
-                batch["detection_boxes"].numpy(),
-                batch["detection_classes"].numpy(),
-                batch["detection_scores"].numpy(),
-        ):
-            predict_result = []
-            for box, label_class, score in zip(boxes, classes, scores):
-                predict_result.append(
-                    {
-                        "detection_boxes": Box2d(*box),
-                        "detection_classes": int(label_class),
-                        "detection_scores": float(score),
-                    }
-                )
-            results.append(predict_result)
+        for image in images:
+            # one image have the shape (x,x,3), but, input needs (1,x,x,3)
+            batch = self.model([image])
+
+            for boxes, classes, scores in zip(
+                    batch["detection_boxes"].numpy(),
+                    batch["detection_classes"].numpy(),
+                    batch["detection_scores"].numpy(),
+            ):
+                predict_result = []
+                for box, label_class, score in zip(boxes, classes, scores):
+                    predict_result.append(
+                        {
+                            "detection_boxes": Box2d(*box),
+                            "detection_classes": int(label_class),
+                            "detection_scores": float(score),
+                        }
+                    )
+                results.append(predict_result)
         return results
 
 

--- a/python/rikai/spark/sql/codegen/tensorflow.py
+++ b/python/rikai/spark/sql/codegen/tensorflow.py
@@ -78,7 +78,7 @@ def _generate(payload: ModelSpec, is_udf: bool = True):
 
             data = PandasDataset(
                 df, model.transform(), unpickle=is_udf, use_pil=True
-            ).data()
+            ).data(batch_size)
 
             results = []
             for batch in data:

--- a/python/rikai/spark/sql/codegen/tensorflow.py
+++ b/python/rikai/spark/sql/codegen/tensorflow.py
@@ -78,14 +78,17 @@ def _generate(payload: ModelSpec, is_udf: bool = True):
 
             data = PandasDataset(
                 df, model.transform(), unpickle=is_udf, use_pil=True
-            ).data(batch_size)
+            ).batch(batch_size)
 
             results = []
             for batch in data:
+                print("one batch!!!")
+                print("batch shape", batch.shape)
                 predictions = model(batch)
                 results.extend(
                     [_pickler.dumps(p) if is_udf else p for p in predictions]
                 )
+            print("out results size", len(results))
             yield pd.Series(results)
 
     if is_udf:

--- a/python/rikai/spark/sql/codegen/tensorflow.py
+++ b/python/rikai/spark/sql/codegen/tensorflow.py
@@ -20,8 +20,8 @@ from pyspark.serializers import CloudPickleSerializer
 from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import BinaryType
 
-from rikai.pytorch.pandas import PandasDataset
 from rikai.spark.sql.model import ModelSpec
+from rikai.tensorflow.pandas import PandasDataset
 from rikai.types import Image
 
 DEFAULT_BATCH_SIZE = 4
@@ -76,17 +76,9 @@ def _generate(payload: ModelSpec, is_udf: bool = True):
             if signature is None:
                 signature = infer_output_signature(df.iloc[0], is_udf)
 
-            ds = PandasDataset(df, unpickle=is_udf, use_pil=True)
-            data = tf.data.Dataset.from_generator(
-                ds,
-                output_signature=tf.TensorSpec(
-                    shape=(None, None, 3), dtype=tf.uint8, name="input_tensor"
-                ),
-            )
-
-            if model.transform():
-                data = data.map(model.transform())
-            data = data.batch(batch_size)
+            data = PandasDataset(
+                df, model.transform(), unpickle=is_udf, use_pil=True
+            ).data()
 
             results = []
             for batch in data:

--- a/python/rikai/spark/sql/codegen/tensorflow.py
+++ b/python/rikai/spark/sql/codegen/tensorflow.py
@@ -82,13 +82,10 @@ def _generate(payload: ModelSpec, is_udf: bool = True):
 
             results = []
             for batch in data:
-                print("one batch!!!")
-                print("batch shape", batch.shape)
                 predictions = model(batch)
                 results.extend(
                     [_pickler.dumps(p) if is_udf else p for p in predictions]
                 )
-            print("out results size", len(results))
             yield pd.Series(results)
 
     if is_udf:

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -51,16 +51,7 @@ class PandasDataset:
         self.use_pil = use_pil
 
     def data(self):
-        # TODO or from generator values?
-        # data = tf.data.Dataset.from_tensor_slices(
-        #     tf.cast(self.df.values, tf.uint8, name="input_tensor")
-        # )
-        data = tf.data.Dataset.from_generator(
-            self.df.values,
-            output_signature=tf.TensorSpec(
-                shape=(None, None, 3), dtype=tf.uint8, name="input_tensor"
-            ),
-        )
+        data = tf.data.Dataset.from_tensor_slices(self.df.to_dict())
         if self.unpickle:
             data.map(unpickle_transform)
 

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -52,12 +52,8 @@ class PandasDataset:
         self.use_pil = use_pil
 
     def batch(self, batch_size):
-        print("batch_size:", batch_size)
-        print("df type", type(self.df))
-        print("df shape shape", self.df.shape)
 
         def upickle_convent_transform(entity):
-            print("arr type", type(entity))
             if self.unpickle:
                 entity = unpickle_transform(entity)
             entity = convert_tensor(entity, use_pil=self.use_pil)
@@ -65,7 +61,6 @@ class PandasDataset:
             from rikai.types.vision import Image
 
             ret = Image.from_pil(entity).to_numpy()
-            print("img shape", ret.shape)
             if self.transform:
                 ret = self.transform(ret)
             return ret

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -51,6 +51,7 @@ class PandasDataset:
         self.use_pil = use_pil
 
     def data(self):
+        # TODO or from generator values?
         data = tf.data.Dataset.from_tensor_slices(
             tf.cast(self.df.values, tf.uint8, name="input_tensor")
         )
@@ -63,10 +64,10 @@ class PandasDataset:
         if self.unpickle:
             data.map(unpickle_transform)
 
-        def convert_tensor_pill(row):
+        def convert_tensor_pil(row):
             return convert_tensor(row, use_pil=self.use_pil)
 
-        data.map(convert_tensor_pill)
+        data.map(convert_tensor_pil)
 
         if self.transform:
             data.map(self.transform)

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -1,0 +1,69 @@
+#  Copyright 2021 Rikai Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Standard
+from typing import Callable, Optional, Union
+
+# Third Party
+import pandas as pd
+import tensorflow as tf
+
+# Rikai
+from rikai.parquet.dataset import convert_tensor
+from rikai.spark.sql.codegen.base import unpickle_transform
+
+__all__ = ["PandasDataset"]
+
+
+class PandasDataset:
+    """a Map-style Pytorch dataset from a :py:class:`pandas.DataFrame` or a
+    :py:class:`pandas.Series`.
+
+    Note
+    ----
+
+    This class is used in Rikai's SQL-ML Spark implementation, which utilizes
+    pandas UDF to run inference.
+    """
+
+    def __init__(
+        self,
+        df: Union[pd.DataFrame, pd.Series],
+        transform: Optional[Callable] = None,
+        unpickle: bool = False,
+        use_pil: bool = False,
+    ) -> None:
+        assert isinstance(df, (pd.DataFrame, pd.Series))
+        self.df = df
+        self.transform = transform
+        self.unpickle = unpickle
+        self.use_pil = use_pil
+
+    def data(self):
+        data = tf.data.Dataset.from_generator(
+            self.df,
+            output_signature=tf.TensorSpec(
+                shape=(None, None, 3), dtype=tf.uint8, name="input_tensor"
+            ),
+        )
+        if self.unpickle:
+            data.map(unpickle_transform)
+
+        def convert_tensor_pill(row):
+            return convert_tensor(row, use_pil=self.use_pil)
+
+        data.map(convert_tensor_pill)
+
+        if self.transform:
+            data.map(self.transform)

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -51,12 +51,15 @@ class PandasDataset:
         self.use_pil = use_pil
 
     def data(self):
-        data = tf.data.Dataset.from_generator(
-            self.df,
-            output_signature=tf.TensorSpec(
-                shape=(None, None, 3), dtype=tf.uint8, name="input_tensor"
-            ),
+        data = tf.data.Dataset.from_tensors(
+            tf.cast(self.df.values, tf.uint8, name="input_tensor")
         )
+        # data = tf.data.Dataset.from_generator(
+        #     self.df,
+        #     output_signature=tf.TensorSpec(
+        #         shape=(None, None, 3), dtype=tf.uint8, name="input_tensor"
+        #     ),
+        # )
         if self.unpickle:
             data.map(unpickle_transform)
 

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -53,24 +53,14 @@ class PandasDataset:
         self.use_pil = use_pil
 
     def data(self, batch_size):
-        # if self.df is a nparray of [Image]
+
         arr = self.df[0]
-        # if isinstance(arr, Image):
-        #     arr = arr.to_numpy()
         if self.unpickle:
             arr = unpickle_transform(arr)
         arr = convert_tensor(arr, use_pil=self.use_pil)
 
         data = tf.data.Dataset.from_tensors(arr)
-        ### move to before from_tensors
-        # if self.unpickle:
-        #     data.map(unpickle_transform)
-        #
-        # def convert_tensor_pil(row):
-        #     return convert_tensor(row, use_pil=self.use_pil)
-        #
-        # data.map(convert_tensor_pil)
-        ###
+
         if self.transform:
             data.map(self.transform)
         data = data.batch(batch_size)

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -70,7 +70,7 @@ class PandasDataset:
                 ret = self.transform(ret)
             return ret
 
-        #TODO I want to use
+        # TODO I want to use
         # `tensors = self.df.map(upickle_convent_transform).to_numpy()`
         # here, but it will cause unintelligible error
         tensors = np.array([upickle_convent_transform(x) for x in self.df])
@@ -78,6 +78,5 @@ class PandasDataset:
         data = tf.data.Dataset.from_tensor_slices(tensors)
         # data = tf.data.Dataset.from_tensors(img)
 
-        # TODO batch seems not available yet
-        data = data.as_numpy_iterator()
+        data = data.batch(batch_size).as_numpy_iterator()
         return data

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -52,7 +52,6 @@ class PandasDataset:
         self.use_pil = use_pil
 
     def batch(self, batch_size):
-
         def upickle_convent_transform(entity):
             if self.unpickle:
                 entity = unpickle_transform(entity)

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -50,9 +50,9 @@ class PandasDataset:
         self.unpickle = unpickle
         self.use_pil = use_pil
 
-    def data(self):
-        print("self df ", self.df)
-        data = tf.data.Dataset.from_tensor_slices(self.df.to_dict())
+    def data(self, batch_size):
+        # self.df is a nparray of [Image]
+        data = tf.data.Dataset.from_tensors(self.df.to_numpy()[0].to_numpy())
         if self.unpickle:
             data.map(unpickle_transform)
 
@@ -63,3 +63,5 @@ class PandasDataset:
 
         if self.transform:
             data.map(self.transform)
+        data = data.batch(batch_size)
+        return data

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -51,6 +51,7 @@ class PandasDataset:
         self.use_pil = use_pil
 
     def data(self):
+        print("self df ", self.df)
         data = tf.data.Dataset.from_tensor_slices(self.df.to_dict())
         if self.unpickle:
             data.map(unpickle_transform)

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -52,15 +52,15 @@ class PandasDataset:
 
     def data(self):
         # TODO or from generator values?
-        data = tf.data.Dataset.from_tensor_slices(
-            tf.cast(self.df.values, tf.uint8, name="input_tensor")
-        )
-        # data = tf.data.Dataset.from_generator(
-        #     self.df,
-        #     output_signature=tf.TensorSpec(
-        #         shape=(None, None, 3), dtype=tf.uint8, name="input_tensor"
-        #     ),
+        # data = tf.data.Dataset.from_tensor_slices(
+        #     tf.cast(self.df.values, tf.uint8, name="input_tensor")
         # )
+        data = tf.data.Dataset.from_generator(
+            self.df.values,
+            output_signature=tf.TensorSpec(
+                shape=(None, None, 3), dtype=tf.uint8, name="input_tensor"
+            ),
+        )
         if self.unpickle:
             data.map(unpickle_transform)
 

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -54,19 +54,23 @@ class PandasDataset:
 
     def data(self, batch_size):
         # if self.df is a nparray of [Image]
-        arr = self.df.to_numpy()[0]
-        if isinstance(arr, Image):
-            arr = arr.to_numpy()
+        arr = self.df[0]
+        # if isinstance(arr, Image):
+        #     arr = arr.to_numpy()
+        if self.unpickle:
+            arr = unpickle_transform(arr)
+        arr = convert_tensor(arr, use_pil=self.use_pil)
 
         data = tf.data.Dataset.from_tensors(arr)
-        if self.unpickle:
-            data.map(unpickle_transform)
-
-        def convert_tensor_pil(row):
-            return convert_tensor(row, use_pil=self.use_pil)
-
-        data.map(convert_tensor_pil)
-
+        ### move to before from_tensors
+        # if self.unpickle:
+        #     data.map(unpickle_transform)
+        #
+        # def convert_tensor_pil(row):
+        #     return convert_tensor(row, use_pil=self.use_pil)
+        #
+        # data.map(convert_tensor_pil)
+        ###
         if self.transform:
             data.map(self.transform)
         data = data.batch(batch_size)

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -51,7 +51,7 @@ class PandasDataset:
         self.use_pil = use_pil
 
     def data(self):
-        data = tf.data.Dataset.from_tensors(
+        data = tf.data.Dataset.from_tensor_slices(
             tf.cast(self.df.values, tf.uint8, name="input_tensor")
         )
         # data = tf.data.Dataset.from_generator(

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -1,4 +1,4 @@
-#  Copyright 2021 Rikai Authors
+#  Copyright 2022 Rikai Authors
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -53,13 +53,21 @@ class PandasDataset:
         self.use_pil = use_pil
 
     def data(self, batch_size):
-
+        print("batch_size:", batch_size)
+        print("df type", type(self.df))
+        print("df shape shape", self.df.shape)
         arr = self.df[0]
+        print("arr type", arr)
         if self.unpickle:
             arr = unpickle_transform(arr)
         arr = convert_tensor(arr, use_pil=self.use_pil)
+        import numpy as np
 
-        data = tf.data.Dataset.from_tensors(arr)
+        from rikai.types.vision import Image
+
+        img = Image.from_pil(arr).to_numpy()
+        # data = tf.data.Dataset.from_tensors(np.array([img,img,img,img,img]))
+        data = tf.data.Dataset.from_tensors(img)
 
         if self.transform:
             data.map(self.transform)

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -39,11 +39,11 @@ class PandasDataset:
     """
 
     def __init__(
-            self,
-            df: pd.Series,
-            transform: Optional[Callable] = None,
-            unpickle: bool = False,
-            use_pil: bool = False,
+        self,
+        df: pd.Series,
+        transform: Optional[Callable] = None,
+        unpickle: bool = False,
+        use_pil: bool = False,
     ) -> None:
         assert isinstance(df, pd.Series)
         self.df = df

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -25,8 +25,6 @@ from rikai.spark.sql.codegen.base import unpickle_transform
 
 __all__ = ["PandasDataset"]
 
-from rikai.types import Image
-
 
 class PandasDataset:
     """a Map-style Tensorflow dataset from a :py:class:`pandas.DataFrame` or a
@@ -40,11 +38,11 @@ class PandasDataset:
     """
 
     def __init__(
-        self,
-        df: Union[pd.DataFrame, pd.Series],
-        transform: Optional[Callable] = None,
-        unpickle: bool = False,
-        use_pil: bool = False,
+            self,
+            df: Union[pd.DataFrame, pd.Series],
+            transform: Optional[Callable] = None,
+            unpickle: bool = False,
+            use_pil: bool = False,
     ) -> None:
         assert isinstance(df, (pd.DataFrame, pd.Series))
         self.df = df
@@ -53,6 +51,7 @@ class PandasDataset:
         self.use_pil = use_pil
 
     def data(self, batch_size):
+        batch_size = 2
         print("batch_size:", batch_size)
         print("df type", type(self.df))
         print("df shape shape", self.df.shape)
@@ -66,10 +65,12 @@ class PandasDataset:
         from rikai.types.vision import Image
 
         img = Image.from_pil(arr).to_numpy()
-        # data = tf.data.Dataset.from_tensors(np.array([img,img,img,img,img]))
-        data = tf.data.Dataset.from_tensors(img)
+        print("img shape", img.shape)
+        data = tf.data.Dataset.from_tensors([img, img, img, img, img, img, img, img, img, img])
+        # data = tf.data.Dataset.from_tensors(img)
 
         if self.transform:
             data.map(self.transform)
-        data = data.batch(batch_size)
+        # TODO batch seems not available yet
+        data = data.as_numpy_iterator()
         return data

--- a/python/rikai/tensorflow/pandas.py
+++ b/python/rikai/tensorflow/pandas.py
@@ -25,9 +25,11 @@ from rikai.spark.sql.codegen.base import unpickle_transform
 
 __all__ = ["PandasDataset"]
 
+from rikai.types import Image
+
 
 class PandasDataset:
-    """a Map-style Pytorch dataset from a :py:class:`pandas.DataFrame` or a
+    """a Map-style Tensorflow dataset from a :py:class:`pandas.DataFrame` or a
     :py:class:`pandas.Series`.
 
     Note
@@ -51,8 +53,12 @@ class PandasDataset:
         self.use_pil = use_pil
 
     def data(self, batch_size):
-        # self.df is a nparray of [Image]
-        data = tf.data.Dataset.from_tensors(self.df.to_numpy()[0].to_numpy())
+        # if self.df is a nparray of [Image]
+        arr = self.df.to_numpy()[0]
+        if isinstance(arr, Image):
+            arr = arr.to_numpy()
+
+        data = tf.data.Dataset.from_tensors(arr)
         if self.unpickle:
             data.map(unpickle_transform)
 


### PR DESCRIPTION
@darcy-shen advised adding some tests to verify the TensorFlow dataset works fine both in a single input picture and muti-pictures.

I added the tests and finally made them pass, but I still have something not intelligible for me.
One thing is 
we can't use `tensors = self.df.map(upickle_convent_transform).to_numpy()` but we can use `tensors = np.array([upickle_convent_transform(x) for x in self.df])`, I believe the former one is more efficient, but tensorflow refused to use it to construct a dataset.

Another thing is, the SSD model only accept data with shape `(1,x,x,3)`, which means we can only pass in one picture into that model, but the picture has to be wrapped in an array with length 1, I can't understand why it's signature should be like that.

I would remove the `print`s after other parts look good to you.