### PR TITLE
Assembly dependencies cleaning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ libraryDependencies ++= {
 
   Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
-    "com.thoughtworks.enableIf" %% "enableif" % enableifVersion exclude (
+    "com.thoughtworks.enableIf" %% "enableif" % enableifVersion % "compile-internal" exclude (
       "org.scala-lang", "scala-reflect"
     ),
     "org.apache.spark" %% "spark-sql" % sparkVersion.value % Provided,
@@ -144,7 +144,7 @@ Antlr4 / antlr4Version := {
   if ("3.1.2".equals(sparkVersion.value)) "4.8-1"
   else "4.8"
 }
-
+Antlr4 / antlr4RuntimeDependency := "org.antlr" % "antlr4-runtime" % (Antlr4 / antlr4Version).value % Provided
 enablePlugins(Antlr4Plugin)
 
 Compile / doc / scalacOptions ++= Seq(
@@ -155,13 +155,6 @@ Compile / doc / scalacOptions ++= Seq(
 assembly / assemblyJarName := s"${name.value}-assembly-${sparkVerStr.value}_${scalaBinaryVersion.value}-${version.value}.jar"
 // Excluding Scala library jars, see https://github.com/sbt/sbt-assembly/tree/v1.2.0#excluding-scala-library-jars
 assemblyPackageScala / assembleArtifact := false
-assembly / assemblyExcludedJars := {
-  val cp = (assembly / fullClasspath).value
-  cp filter { x =>
-    x.data.getName.contains("antlr4-runtime") ||
-      x.data.getName.contains("enableif")
-  }
-}
 
 publishLocal := {
   val ivyHome = ivyPaths.value.ivyHome.get.getCanonicalPath

--- a/build.sbt
+++ b/build.sbt
@@ -73,8 +73,6 @@ libraryDependencies ++= {
   val scalaLoggingVersion = "3.9.4"
   val snappyVersion = "1.1.8.4" // Support Apple Silicon
   val scalatestVersion = "3.2.0"
-  val hadoopVersion = "3.2.3"
-  val circeVersion = "0.12.3"
   val mlflowVersion = "1.21.0"
   val enableifVersion = "1.1.8"
 
@@ -95,9 +93,6 @@ libraryDependencies ++= {
       "org.scala-lang", "scala-reflect"
     ),
     "org.scalatest" %% "scalatest-funsuite" % scalatestVersion % Test,
-    "io.circe" %% "circe-core" % circeVersion,
-    "io.circe" %% "circe-generic" % circeVersion,
-    "io.circe" %% "circe-parser" % circeVersion,
     "org.mlflow" % "mlflow-client" % mlflowVersion
   )
 }
@@ -154,6 +149,7 @@ Compile / doc / scalacOptions ++= Seq(
 )
 
 assembly / assemblyJarName := s"${name.value}-assembly-${sparkVerStr.value}_${scalaBinaryVersion.value}-${version.value}.jar"
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 publishLocal := {
   val ivyHome = ivyPaths.value.ivyHome.get.getCanonicalPath

--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,7 @@ libraryDependencies ++= {
   val scalaLoggingVersion = "3.9.4"
   val snappyVersion = "1.1.8.4" // Support Apple Silicon
   val scalatestVersion = "3.2.0"
+  val hadoopVersion = "3.2.3"
   val mlflowVersion = "1.21.0"
   val enableifVersion = "1.1.8"
 
@@ -85,7 +86,7 @@ libraryDependencies ++= {
     "org.apache.spark" %% "spark-core" % sparkVersion.value % Test classifier "tests",
     "org.apache.spark" %% "spark-hive-thriftserver" % sparkVersion.value % Test,
     "org.apache.spark" %% "spark-hive-thriftserver" % sparkVersion.value % Test classifier "tests",
-    "org.apache.hadoop" % "hadoop-common" % hadoopVersion,
+    "org.apache.hadoop" % "hadoop-common" % hadoopVersion % Provided,
     "software.amazon.awssdk" % "s3" % awsVersion % Provided,
     "org.xerial.snappy" % "snappy-java" % snappyVersion,
     "org.apache.logging.log4j" % "log4j-core" % log4jVersion % Runtime,

--- a/build.sbt
+++ b/build.sbt
@@ -153,6 +153,7 @@ Compile / doc / scalacOptions ++= Seq(
 )
 
 assembly / assemblyJarName := s"${name.value}-assembly-${sparkVerStr.value}_${scalaBinaryVersion.value}-${version.value}.jar"
+// Excluding Scala library jars, see https://github.com/sbt/sbt-assembly/tree/v1.2.0#excluding-scala-library-jars
 assemblyPackageScala / assembleArtifact := false
 assembly / assemblyExcludedJars := {
   val cp = (assembly / fullClasspath).value

--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,10 @@ Test / fork := true
 
 Antlr4 / antlr4PackageName := Some("ai.eto.rikai.sql.spark.parser")
 Antlr4 / antlr4GenVisitor := true
-Antlr4 / antlr4Version := "4.8-1"
+Antlr4 / antlr4Version := {
+  if ("3.1.2".equals(sparkVersion.value)) "4.8-1"
+  else "4.8"
+}
 
 enablePlugins(Antlr4Plugin)
 
@@ -149,7 +152,14 @@ Compile / doc / scalacOptions ++= Seq(
 )
 
 assembly / assemblyJarName := s"${name.value}-assembly-${sparkVerStr.value}_${scalaBinaryVersion.value}-${version.value}.jar"
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+assemblyPackageScala / assembleArtifact := false
+assembly / assemblyExcludedJars := {
+  val cp = (assembly / fullClasspath).value
+  cp filter { x =>
+    x.data.getName.contains("antlr4-runtime") ||
+      x.data.getName.contains("enableif")
+  }
+}
 
 publishLocal := {
   val ivyHome = ivyPaths.value.ivyHome.get.getCanonicalPath

--- a/src/main/scala/ai/eto/rikai/sql/model/Model.scala
+++ b/src/main/scala/ai/eto/rikai/sql/model/Model.scala
@@ -17,11 +17,11 @@
 package ai.eto.rikai.sql.model
 
 import ai.eto.rikai.sql.spark.SparkRunnable
-import io.circe.syntax._
-import io.circe.generic.encoding.DerivedAsObjectEncoder._
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression}
+import org.json4s.DefaultFormats
+import org.json4s.jackson.Serialization.write
 
 import scala.collection.JavaConverters.mapAsJavaMap
 
@@ -59,7 +59,7 @@ object Model {
 
   def serializeOptions(options: Map[String, String]): String = {
     if (options.isEmpty) ""
-    else options.asJson.noSpaces
+    else write(options)(DefaultFormats)
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/rikai/model/ModelResolver.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/model/ModelResolver.scala
@@ -79,7 +79,8 @@ object ModelResolver {
     val path = Files.createTempFile("model-code", ".cpt")
     val dataTypePath = Files.createTempFile("model-type", ".json")
     try {
-      Files.write(specPath, write(spec)(DefaultFormats).getBytes)
+      implicit val writeFormat = DefaultFormats.preservingEmptyValues
+      Files.write(specPath, write(spec).getBytes)
       Python.execute(
         s"""from pyspark.serializers import CloudPickleSerializer;
            |import json
@@ -100,7 +101,7 @@ object ModelResolver {
         session
       )
       val cmdJson = Files.readAllLines(path).asScala.mkString("\n")
-      implicit val formats = Serialization.formats(NoTypeHints)
+      implicit val extractFormat = Serialization.formats(NoTypeHints)
       val cmdMap = parse(cmdJson).extract[FuncDesc]
       val dataTypeJson = Files.readAllLines(dataTypePath).asScala.mkString("\n")
       val returnType = DataType.fromJson(dataTypeJson)

--- a/src/main/scala/org/apache/spark/sql/rikai/model/ModelResolver.scala
+++ b/src/main/scala/org/apache/spark/sql/rikai/model/ModelResolver.scala
@@ -18,13 +18,14 @@ package org.apache.spark.sql.rikai.model
 
 import ai.eto.rikai.sql.model.{ModelSpec, SparkUDFModel}
 import ai.eto.rikai.sql.spark.Python
-import io.circe.generic.auto._
-import io.circe.parser.decode
-import io.circe.syntax._
 import org.apache.spark.api.python.{PythonEvalType, PythonFunction}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.python.UserDefinedPythonFunction
 import org.apache.spark.sql.types.{BinaryType, DataType}
+import org.json4s.{DefaultFormats, NoTypeHints}
+import org.json4s.jackson.Serialization.write
+import org.json4s.jackson.JsonMethods.parse
+import org.json4s.jackson.Serialization
 
 import java.nio.file.Files
 import java.util.Base64
@@ -78,7 +79,7 @@ object ModelResolver {
     val path = Files.createTempFile("model-code", ".cpt")
     val dataTypePath = Files.createTempFile("model-type", ".json")
     try {
-      Files.write(specPath, spec.asJson.toString.getBytes)
+      Files.write(specPath, write(spec)(DefaultFormats).getBytes)
       Python.execute(
         s"""from pyspark.serializers import CloudPickleSerializer;
            |import json
@@ -99,11 +100,8 @@ object ModelResolver {
         session
       )
       val cmdJson = Files.readAllLines(path).asScala.mkString("\n")
-      val cmdMap = decode[FuncDesc](cmdJson) match {
-        case Left(failure) => throw failure
-        case Right(json)   => json
-      }
-
+      implicit val formats = Serialization.formats(NoTypeHints)
+      val cmdMap = parse(cmdJson).extract[FuncDesc]
       val dataTypeJson = Files.readAllLines(dataTypePath).asScala.mkString("\n")
       val returnType = DataType.fromJson(dataTypeJson)
       val suffix: String = Random.alphanumeric.take(6).mkString.toLowerCase


### PR DESCRIPTION
closes #588 
Reduce the assembly jar size from 28.5M to 12M by:
+ Replace circe with Spark-shipped json4s
+ Remove scala-library
+ Remove enableIf.scala