### PR TITLE
Allow set parquet block size via option

### DIFF
--- a/src/main/scala/ai/eto/rikai/RikaiOptions.scala
+++ b/src/main/scala/ai/eto/rikai/RikaiOptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Rikai authors
+ * Copyright 2022 Rikai authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,13 @@ private[rikai] class RikaiOptions(parameters: Map[String, String]) {
     */
   val path: String = parameters.getOrElse("path", "")
 
-  val defaultBlockSize: Int = 32 * 1024 * 1024
-
   /** Parquet block size. */
   val blockSize: Int =
-    parameters.getOrElse("rikai.block.size", s"${defaultBlockSize}").toInt
+    parameters
+      .getOrElse("rikai.block.size", s"${RikaiOptions.defaultBlockSize}")
+      .toInt
+}
+
+private[rikai] object RikaiOptions {
+  val defaultBlockSize: Int = 32 * 1024 * 1024
 }

--- a/src/main/scala/ai/eto/rikai/RikaiOptions.scala
+++ b/src/main/scala/ai/eto/rikai/RikaiOptions.scala
@@ -26,5 +26,5 @@ private[rikai] class RikaiOptions(parameters: Map[String, String]) {
 
   /** Parquet block size. */
   val blockSize: Int =
-    parameters.getOrElse("rikai.block.size", s"${blockSize}").toInt
+    parameters.getOrElse("rikai.block.size", s"${defaultBlockSize}").toInt
 }

--- a/src/main/scala/ai/eto/rikai/RikaiOptions.scala
+++ b/src/main/scala/ai/eto/rikai/RikaiOptions.scala
@@ -21,4 +21,8 @@ private[rikai] class RikaiOptions(parameters: Map[String, String]) {
   /** Base path for the feature dataset
     */
   val path: String = parameters.getOrElse("path", "")
+
+  /** Parquet block size. */
+  val blockSize: Int =
+    parameters.getOrElse("rikai.block.size", s"${32 * 1024 * 1024}").toInt
 }

--- a/src/main/scala/ai/eto/rikai/RikaiOptions.scala
+++ b/src/main/scala/ai/eto/rikai/RikaiOptions.scala
@@ -22,7 +22,9 @@ private[rikai] class RikaiOptions(parameters: Map[String, String]) {
     */
   val path: String = parameters.getOrElse("path", "")
 
+  val defaultBlockSize: Int = 32 * 1024 * 1024
+
   /** Parquet block size. */
   val blockSize: Int =
-    parameters.getOrElse("rikai.block.size", s"${32 * 1024 * 1024}").toInt
+    parameters.getOrElse("rikai.block.size", s"${blockSize}").toInt
 }

--- a/src/main/scala/ai/eto/rikai/RikaiRelation.scala
+++ b/src/main/scala/ai/eto/rikai/RikaiRelation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Rikai authors
+ * Copyright 2022 Rikai authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ class RikaiRelation(val options: RikaiOptions)(
 
   /** Pruned and filtered scan
     *
-    * @param requiredColumns
+    * @param requiredColumns the required columns to be loaded.
     * @param filters
     *
     * @return
@@ -68,7 +68,7 @@ class RikaiRelation(val options: RikaiOptions)(
     for (filter <- filters) {
       df = FilterUtils.apply(df, filter)
     }
-    return df.rdd
+    df.rdd
   }
 
   /** Write data
@@ -80,7 +80,6 @@ class RikaiRelation(val options: RikaiOptions)(
       data: org.apache.spark.sql.DataFrame,
       overwrite: Boolean
   ): Unit = {
-    // println(s"Rikai writing to ${options.path}")
     var writer = data.write.format("parquet")
     if (overwrite) {
       writer = writer.mode(SaveMode.Overwrite)

--- a/src/test/scala/ai/eto/rikai/RikaiRelationTest.scala
+++ b/src/test/scala/ai/eto/rikai/RikaiRelationTest.scala
@@ -57,4 +57,9 @@ class RikaiRelationTest extends AnyFunSuite with SparkTestSession {
     val df = spark.read.rikai(testDir.toString)
     assert(df.intersectAll(examples).count == 3)
   }
+
+  test("test default block size") {
+    val options = new RikaiOptions(Map.empty)
+    assert(options.blockSize == RikaiOptions.defaultBlockSize)
+  }
 }

--- a/src/test/scala/ai/eto/rikai/RikaiRelationTest.scala
+++ b/src/test/scala/ai/eto/rikai/RikaiRelationTest.scala
@@ -50,9 +50,9 @@ class RikaiRelationTest extends AnyFunSuite with SparkTestSession {
     import ai.eto.rikai._
     examples.write.rikai(testDir.toString)
 
-    val numParquetFileds =
+    val numParquetFiles =
       testDir.list().count(_.endsWith(".parquet"))
-    assert(numParquetFileds > 0)
+    assert(numParquetFiles > 0)
 
     val df = spark.read.rikai(testDir.toString)
     assert(df.intersectAll(examples).count == 3)


### PR DESCRIPTION
Use 

```python
df.write.format("rikai").option("rikai.block.size", 12345).save("dest")
```

to customize block size in the resulted parquet files.