### PR TITLE
Release assembly jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,7 @@ Compile / doc / scalacOptions ++= Seq(
   "ai.eto.rikai.sql.spark.parser"
 )
 
-assembly / assemblyJarName := s"${name.value}-assembly-${sparkVerStr.value}_${scalaBinaryVersion.value}-${version.value}.jar"
+assembly / assemblyJarName := s"${name.value}-${sparkVerStr.value}_${scalaBinaryVersion.value}-assembly-${version.value}.jar"
 // Excluding Scala library jars, see https://github.com/sbt/sbt-assembly/tree/v1.2.0#excluding-scala-library-jars
 assemblyPackageScala / assembleArtifact := false
 
@@ -171,3 +171,12 @@ publishLocal := {
   }
   publishLocal.value
 }
+
+assembly / artifact := {
+  val art = (assembly / artifact).value
+  art.withName(s"${name.value}-${sparkVerStr.value}").withClassifier(Some(s"assembly"))
+}
+
+addArtifact(assembly / artifact, assembly)
+
+test in assembly := {}

--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,7 @@ Compile / doc / scalacOptions ++= Seq(
   "ai.eto.rikai.sql.spark.parser"
 )
 
-assembly / assemblyJarName := s"${name.value}-${sparkVerStr.value}_${scalaBinaryVersion.value}-assembly-${version.value}.jar"
+assembly / assemblyJarName := s"${name.value}-${sparkVerStr.value}-assembly_${scalaBinaryVersion.value}-${version.value}.jar"
 // Excluding Scala library jars, see https://github.com/sbt/sbt-assembly/tree/v1.2.0#excluding-scala-library-jars
 assemblyPackageScala / assembleArtifact := false
 
@@ -174,7 +174,7 @@ publishLocal := {
 
 assembly / artifact := {
   val art = (assembly / artifact).value
-  art.withName(s"${name.value}-${sparkVerStr.value}").withClassifier(Some(s"assembly"))
+  art.withName(s"${name.value}-${sparkVerStr.value}-assembly")
 }
 
 addArtifact(assembly / artifact, assembly)


### PR DESCRIPTION
closes #386

+ sbt publishLocal
   - `$HOME/.ivy2/local/ai.eto/rikai_2.12/0.1.9-SNAPSHOT/jars/rikai-spark312-assembly_2.12.jar`
+ SPARK_VERSION=3.2.1 sbt publishLocal
   - `$HOME/.ivy2/local/ai.eto/rikai_2.12/0.1.9-SNAPSHOT/jars/rikai-spark321-assembly_2.12.jar`
+ sbt clean assembly
   - `rikai-spark312-assembly_2.12-0.1.9-SNAPSHOT.jar`
+ SPARK_VERSION=3.2.1 sbt clean assembly
   - `rikai-spark321-assembly_2.12-0.1.9-SNAPSHOT.jar`