### PR TITLE
Box2d label

### DIFF
--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -23,6 +23,7 @@ from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from PIL import Image, ImageDraw
+from rikai.conf import CONF_RIKAI_VIZ_COLOR, get_option
 
 from rikai.mixin import Drawable, ToDict, ToNumpy
 from rikai.spark.types.geometry import (
@@ -34,6 +35,8 @@ from rikai.spark.types.geometry import (
 from rikai.types import rle
 
 __all__ = ["Point", "Box3d", "Box2d", "Mask"]
+
+from rikai.viz import Text
 
 
 class Point(ToNumpy, ToDict):
@@ -391,6 +394,24 @@ class Box2d(ToNumpy, Sequence, ToDict, Drawable):
         if isinstance(other, Box2d):
             return iou_arr[0]
         return iou_arr
+
+    def with_label(self, text: str, color: str = get_option(CONF_RIKAI_VIZ_COLOR)):
+        """Spawn a list with current box and a `python.rikai.viz.Text`
+
+        Parameters
+        ----------
+        text: str
+            The text content of that label
+        color: str
+            The color of the text, will have a default value if not given.
+
+        Returns
+        -------
+        list
+            [self, the_label]
+        """
+        return [self, Text(text, (self.xmin, self.ymin), color)]
+
 
 
 class Box3d(ToNumpy, ToDict):

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -398,7 +398,8 @@ class Box2d(ToNumpy, Sequence, ToDict, Drawable):
     def with_label(
         self, text: str, color: str = get_option(CONF_RIKAI_VIZ_COLOR)
     ):
-        """Spawn a list with current box and a `python.rikai.viz.Text`
+        """Spawn a list with current box and a `python.rikai.viz.Text`, the later one would be aligned with
+        current box on left-top, used as a convenient tool to give a box a label in visualization.
 
         Parameters
         ----------

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -395,7 +395,9 @@ class Box2d(ToNumpy, Sequence, ToDict, Drawable):
             return iou_arr[0]
         return iou_arr
 
-    def with_label(self, text: str, color: str = get_option(CONF_RIKAI_VIZ_COLOR)):
+    def with_label(
+        self, text: str, color: str = get_option(CONF_RIKAI_VIZ_COLOR)
+    ):
         """Spawn a list with current box and a `python.rikai.viz.Text`
 
         Parameters
@@ -411,7 +413,6 @@ class Box2d(ToNumpy, Sequence, ToDict, Drawable):
             [self, the_label]
         """
         return [self, Text(text, (self.xmin, self.ymin), color)]
-
 
 
 class Box3d(ToNumpy, ToDict):

--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -199,7 +199,7 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
     def __eq__(self, other) -> bool:
         return isinstance(other, Image) and super().__eq__(other)
 
-    def __or__(self, other: Drawable) -> Draw:
+    def __or__(self, other: Union[Drawable, list[Drawable]]) -> Draw:
         """Override ``|`` operator to chain images with
         visualization components.
         """

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -217,7 +217,7 @@ def test_draw_box_with_label():
     # expected.show()
     assert np.array_equal(pil_image.to_numpy(), expected)
 
-# TODO draw styled label
+
 def test_draw_styled_images():
     data = np.random.randint(0, 255, size=(100, 100, 3), dtype=np.uint8)
     img = Image.from_array(data)

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -197,6 +197,27 @@ def test_draw_image():
     assert np.array_equal(pil_image.to_numpy(), expected)
 
 
+def test_draw_box_with_label():
+    data = np.random.randint(0, 255, size=(100, 100, 3), dtype=np.uint8)
+    img = Image.from_array(data)
+
+    box1 = Box2d(1, 2, 10, 12)
+    box2 = Box2d(20, 20, 40, 40)
+    draw_boxes = img | box1.with_label("label1") | box2.with_label("label2")
+    pil_image = draw_boxes.to_image()
+
+    expected = Image.from_array(data).to_pil()
+    draw = PILImageDraw.Draw(expected)
+    draw.rectangle((1.0, 2.0, 10.0, 12.0), outline="red")
+    draw.text((1, 2), "label1", fill="red")
+    draw.rectangle((20, 20, 40, 40), outline="red")
+    draw.text((20, 20), "label2", fill="red")
+    # If you need to see the pics in your local computer.
+    # pil_image.to_pil().show()
+    # expected.show()
+    assert np.array_equal(pil_image.to_numpy(), expected)
+
+# TODO draw styled label
 def test_draw_styled_images():
     data = np.random.randint(0, 255, size=(100, 100, 3), dtype=np.uint8)
     img = Image.from_array(data)


### PR DESCRIPTION
I also tried to implement something like this
```
    sugar_boxes = (
        img
        | box1.with_label('label1') @ {"color": "green", "width": 10}
        | box2.with_label('label2') @ {"color": "green", "width": 10}
    )
```

But it seems we can't do it by just returning a list for `with_label`. If we need to enable this sugar, maybe we still need something like `ComposedDrawable`.