### PR TITLE
Support partitionBy with Rikai dataframe writer in Spark

### DIFF
--- a/src/main/scala/ai/eto/rikai/RikaiOptions.scala
+++ b/src/main/scala/ai/eto/rikai/RikaiOptions.scala
@@ -33,6 +33,19 @@ private[rikai] class RikaiOptions(parameters: Map[String, String]) {
     parameters
       .filterKeys(k => !RikaiOptions.excludedKeys(k))
       .toMap
+
+  /** Columns specified via df.partitionBy() */
+  val partitionColumns: Option[Seq[String]] =
+    parameters.get("__partition_columns") match {
+      case Some(cols) =>
+        Some(
+          cols
+            .substring(1, cols.length - 1)
+            .split(",")
+            .map(_.stripPrefix("\"").stripSuffix("\""))
+        )
+      case None => None
+    }
 }
 
 private[rikai] object RikaiOptions {

--- a/src/main/scala/ai/eto/rikai/RikaiRelation.scala
+++ b/src/main/scala/ai/eto/rikai/RikaiRelation.scala
@@ -109,6 +109,10 @@ class RikaiRelation(val options: RikaiOptions)(
     if (overwrite) {
       writer = writer.mode(SaveMode.Overwrite)
     }
+    writer = options.partitionColumns match {
+      case Some(cols) => writer.partitionBy(cols: _*)
+      case None       => writer
+    }
     val total = writer.save(options.path)
 
     writeMetadataFile()

--- a/src/test/scala/ai/eto/rikai/RikaiRelationTest.scala
+++ b/src/test/scala/ai/eto/rikai/RikaiRelationTest.scala
@@ -58,6 +58,15 @@ class RikaiRelationTest extends AnyFunSuite with SparkTestSession {
     assert(df.intersectAll(examples).count == 3)
   }
 
+  test("Use partitions") {
+    examples.write.partitionBy("label").rikai(testDir.toString)
+
+    val partitions =
+      Set(testDir.list().toSeq.filter(_.startsWith("label=")): _*)
+
+    assert(partitions == Set("label=car", "label=people", "label=tree"))
+  }
+
   test("test default block size") {
     val options = new RikaiOptions(Map.empty)
     assert(options.blockSize == RikaiOptions.defaultBlockSize)


### PR DESCRIPTION
`df.write.rikai()` supports `partitionBy(col, ...)`