### PR TITLE
Pin antlr version

### DIFF
--- a/python/deps/requirements_rtd.txt
+++ b/python/deps/requirements_rtd.txt
@@ -1,4 +1,4 @@
-antlr4-python3-runtime
+antlr4-python3-runtime==4.8
 numpy
 opencv-python
 pandas


### PR DESCRIPTION
Read the doc failed to generate api doc due to `antlr` version mismatch.

https://readthedocs.org/projects/rikai/builds/16773562/