### PR TITLE
Box2d label with `Draw`

### DIFF
--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -416,7 +416,16 @@ class Box2d(ToNumpy, Sequence, ToDict, Drawable):
         """
         # TODO add font size
         return Draw(
-            [self, Text(text, (int(self.xmin), int(self.ymin)), color)]
+            [
+                self,
+                Text(
+                    # `ymin - 10` to let the label don't overlap
+                    # with box by default find a better way later
+                    text,
+                    (int(self.xmin), int(min(self.ymin - 10, 0))),
+                    color,
+                ),
+            ]
         )
 
 

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -22,8 +22,10 @@ from numbers import Real
 from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
+from pandas import get_option
 from PIL import Image, ImageDraw
 
+from rikai import CONF_RIKAI_VIZ_COLOR
 from rikai.mixin import Drawable, ToDict, ToNumpy
 from rikai.spark.types.geometry import (
     Box2dType,
@@ -391,6 +393,28 @@ class Box2d(ToNumpy, Sequence, ToDict, Drawable):
         if isinstance(other, Box2d):
             return iou_arr[0]
         return iou_arr
+
+    def with_label(
+        self, text: str, color: str = get_option(CONF_RIKAI_VIZ_COLOR)
+    ) -> "rikai.viz.Draw":
+        from rikai.viz import Draw, Text
+
+        """return a `rikai.viz.Draw`, which contains a label,
+         used as a convenient tool to give a box a label in visualization.
+        Parameters
+        ----------
+        text: str
+            The text content of that label
+        color: str
+            The color of the text, will have a default value if not given.
+        Returns
+        -------
+        box_with_label
+            rikai.viz.Draw
+        """
+        return Draw(
+            [self, Text(text, (int(self.xmin), int(self.ymin)), color)]
+        )
 
 
 class Box3d(ToNumpy, ToDict):

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -400,13 +400,15 @@ class Box2d(ToNumpy, Sequence, ToDict, Drawable):
         from rikai.viz import Draw, Text
 
         """return a `rikai.viz.Draw`, which contains a label,
-         used as a convenient tool to give a box a label in visualization.
+        used as a convenient tool to give a box a label
+        in visualization.
         Parameters
         ----------
         text: str
             The text content of that label
         color: str
-            The color of the text, will have a default value if not given.
+            The color of the text,
+            will have a default value if not given.
         Returns
         -------
         box_with_label

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -422,7 +422,7 @@ class Box2d(ToNumpy, Sequence, ToDict, Drawable):
                     # `ymin - 10` to let the label don't overlap
                     # with box by default find a better way later
                     text,
-                    (int(self.xmin), int(min(self.ymin - 10, 0))),
+                    (int(self.xmin), int(max(self.ymin - 10, 0))),
                     color,
                 ),
             ]

--- a/python/rikai/types/geometry.py
+++ b/python/rikai/types/geometry.py
@@ -412,6 +412,7 @@ class Box2d(ToNumpy, Sequence, ToDict, Drawable):
         box_with_label
             rikai.viz.Draw
         """
+        # TODO add font size
         return Draw(
             [self, Text(text, (int(self.xmin), int(self.ymin)), color)]
         )

--- a/python/rikai/types/vision.py
+++ b/python/rikai/types/vision.py
@@ -182,7 +182,7 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
                 url = f"data:image;base64,{encoded}"
                 return Image(url=url, format=inferred_format)
 
-    def draw(self, drawable: Union[Drawable, list[Drawable]]) -> Draw:
+    def draw(self, drawable: Union[Drawable, list[Drawable], Draw]) -> Draw:
         return ImageDraw(self).draw(drawable)
 
     def __repr__(self) -> str:
@@ -199,7 +199,7 @@ class Image(ToNumpy, ToPIL, Asset, Displayable, ToDict):
     def __eq__(self, other) -> bool:
         return isinstance(other, Image) and super().__eq__(other)
 
-    def __or__(self, other: Drawable) -> Draw:
+    def __or__(self, other: Union[Drawable, Draw]) -> Draw:
         """Override ``|`` operator to chain images with
         visualization components.
         """

--- a/python/rikai/viz.py
+++ b/python/rikai/viz.py
@@ -85,11 +85,13 @@ class Draw(Displayable, ABC):
             include=include, exclude=exclude
         )
 
-    def draw(self, layer: Union[Drawable, list[Drawable]]) -> Draw:
+    def draw(self, layer: Union[Drawable, list[Drawable], Draw]) -> Draw:
         # layer can not be checked against typing.Sequence or typing.Iterable,
         # because many of the Drawables are iterables (i.e., Box2d).
         if isinstance(layer, Drawable):
             layer = [layer]
+        if isinstance(layer, Draw):
+            layer = layer.layers
         elif not isinstance(layer, (Drawable, list)):
             raise ValueError(
                 f"{layer} must be one Drawable or a list of Drawable"

--- a/python/rikai/viz.py
+++ b/python/rikai/viz.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, Mapping
 
 import numpy as np
 from PIL import Image as PILImage
@@ -72,8 +72,10 @@ class Style(Drawable):
 class Draw(Displayable, ABC):
     """Draw is a container that contain the elements for visualized lazily."""
 
-    def __init__(self):
-        self.layers = []
+    def __init__(self, layers=None):
+        if layers is None:
+            layers = []
+        self.layers = layers
 
     def __repr__(self):
         first_layer = self.layers[0] if self.layers else "N/A"
@@ -101,6 +103,10 @@ class Draw(Displayable, ABC):
 
     def __or__(self, other: Union[Drawable, list[Drawable]]) -> Draw:
         return self.draw(other)
+
+    def __matmul__(self, style: Union[dict, "rikai.viz.Style"]) -> Draw:
+        new_layers = [x @ style for x in self.layers]
+        return Draw(new_layers)
 
 
 class Renderer(ABC):

--- a/python/rikai/viz.py
+++ b/python/rikai/viz.py
@@ -72,6 +72,11 @@ class Style(Drawable):
 class Draw(Displayable, ABC):
     """Draw is a container that contain the elements for visualized lazily."""
 
+    def display(self, **kwargs) -> "IPython.display.DisplayObject":
+        """We need to instantiate Draw, so we need to make it a concrete class, but we should
+        not call Draw's display method directly"""
+        raise NotImplemented
+
     def __init__(self, layers=None):
         if layers is None:
             layers = []

--- a/python/rikai/viz.py
+++ b/python/rikai/viz.py
@@ -73,8 +73,8 @@ class Draw(Displayable, ABC):
     """Draw is a container that contain the elements for visualized lazily."""
 
     def display(self, **kwargs) -> "IPython.display.DisplayObject":
-        """We need to instantiate Draw, so we need to make it a concrete class, but we should
-        not call Draw's display method directly"""
+        """We need to instantiate Draw, so we need to make it a concrete class,
+        but we should not call Draw's display method directly"""
         raise NotImplemented
 
     def __init__(self, layers=None):

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -224,7 +224,11 @@ def test_draw_box_with_label_matmul():
 
     box1 = Box2d(1, 2, 10, 12)
     box2 = Box2d(20, 20, 40, 40)
-    draw_boxes = img | box1.with_label("label1") @ {"color": "green"} | box2.with_label("label2") @ {"color": "yellow"}
+    draw_boxes = (
+        img
+        | box1.with_label("label1") @ {"color": "green"}
+        | box2.with_label("label2") @ {"color": "yellow"}
+    )
     pil_image = draw_boxes.to_image()
 
     expected = Image.from_array(data).to_pil()
@@ -237,6 +241,7 @@ def test_draw_box_with_label_matmul():
     # pil_image.to_pil().show()
     # expected.show()
     assert np.array_equal(pil_image.to_numpy(), expected)
+
 
 def test_draw_styled_images():
     data = np.random.randint(0, 255, size=(100, 100, 3), dtype=np.uint8)

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -209,9 +209,9 @@ def test_draw_box_with_label():
     expected = Image.from_array(data).to_pil()
     draw = PILImageDraw.Draw(expected)
     draw.rectangle((1.0, 2.0, 10.0, 12.0), outline="red")
-    draw.text((1, 2), "label1", fill="red")
+    draw.text((1, 0), "label1", fill="red")
     draw.rectangle((20, 20, 40, 40), outline="red")
-    draw.text((20, 20), "label2", fill="red")
+    draw.text((20, 10), "label2", fill="red")
     # If you need to see the pics in your local computer.
     # pil_image.to_pil().show()
     # expected.show()
@@ -234,9 +234,9 @@ def test_draw_box_with_label_matmul():
     expected = Image.from_array(data).to_pil()
     draw = PILImageDraw.Draw(expected)
     draw.rectangle((1.0, 2.0, 10.0, 12.0), outline="green")
-    draw.text((1, 2), "label1", fill="green")
+    draw.text((1, 0), "label1", fill="green")
     draw.rectangle((20, 20, 40, 40), outline="yellow")
-    draw.text((20, 20), "label2", fill="yellow")
+    draw.text((20, 10), "label2", fill="yellow")
     # If you need to see the pics in your local computer.
     # pil_image.to_pil().show()
     # expected.show()

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -197,6 +197,26 @@ def test_draw_image():
     assert np.array_equal(pil_image.to_numpy(), expected)
 
 
+def test_draw_box_with_label():
+    data = np.random.randint(0, 255, size=(100, 100, 3), dtype=np.uint8)
+    img = Image.from_array(data)
+
+    box1 = Box2d(1, 2, 10, 12)
+    box2 = Box2d(20, 20, 40, 40)
+    draw_boxes = img | box1.with_label("label1") | box2.with_label("label2")
+    pil_image = draw_boxes.to_image()
+
+    expected = Image.from_array(data).to_pil()
+    draw = PILImageDraw.Draw(expected)
+    draw.rectangle((1.0, 2.0, 10.0, 12.0), outline="red")
+    draw.text((1, 2), "label1", fill="red")
+    draw.rectangle((20, 20, 40, 40), outline="red")
+    draw.text((20, 20), "label2", fill="red")
+    # If you need to see the pics in your local computer.
+    # pil_image.to_pil().show()
+    # expected.show()
+    assert np.array_equal(pil_image.to_numpy(), expected)
+
 def test_draw_styled_images():
     data = np.random.randint(0, 255, size=(100, 100, 3), dtype=np.uint8)
     img = Image.from_array(data)

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -218,6 +218,26 @@ def test_draw_box_with_label():
     assert np.array_equal(pil_image.to_numpy(), expected)
 
 
+def test_draw_box_with_label_matmul():
+    data = np.random.randint(0, 255, size=(100, 100, 3), dtype=np.uint8)
+    img = Image.from_array(data)
+
+    box1 = Box2d(1, 2, 10, 12)
+    box2 = Box2d(20, 20, 40, 40)
+    draw_boxes = img | box1.with_label("label1") @ {"color": "green"} | box2.with_label("label2") @ {"color": "yellow"}
+    pil_image = draw_boxes.to_image()
+
+    expected = Image.from_array(data).to_pil()
+    draw = PILImageDraw.Draw(expected)
+    draw.rectangle((1.0, 2.0, 10.0, 12.0), outline="green")
+    draw.text((1, 2), "label1", fill="green")
+    draw.rectangle((20, 20, 40, 40), outline="yellow")
+    draw.text((20, 20), "label2", fill="yellow")
+    # If you need to see the pics in your local computer.
+    # pil_image.to_pil().show()
+    # expected.show()
+    assert np.array_equal(pil_image.to_numpy(), expected)
+
 def test_draw_styled_images():
     data = np.random.randint(0, 255, size=(100, 100, 3), dtype=np.uint8)
     img = Image.from_array(data)

--- a/python/tests/types/test_vision.py
+++ b/python/tests/types/test_vision.py
@@ -217,6 +217,7 @@ def test_draw_box_with_label():
     # expected.show()
     assert np.array_equal(pil_image.to_numpy(), expected)
 
+
 def test_draw_styled_images():
     data = np.random.randint(0, 255, size=(100, 100, 3), dtype=np.uint8)
     img = Image.from_array(data)


### PR DESCRIPTION
Similar to https://github.com/eto-ai/rikai/pull/632, but extend `Draw` instead of using a list.
It can have a sugar
```
.... @ {"color": "green", "width": 10}
```
which list hasn't.

part of https://github.com/eto-ai/rikai/issues/550