### PR TITLE
fix dataset conversion for nested structs

### DIFF
--- a/python/rikai/parquet/dataset.py
+++ b/python/rikai/parquet/dataset.py
@@ -194,10 +194,7 @@ class Dataset:
                     raw_row[name], field_type["elementType"]
                 )
             elif field_type["type"] == "struct":
-                converted[name] = {
-                    f["name"]: self._convert(raw_row[f["name"]], f["type"])
-                    for f in field_type["type"]["fields"]
-                }
+                converted[name] = self._convert(raw_row[name], field_type)
             else:
                 converted[name] = raw_row[name]
 


### PR DESCRIPTION
nest struct conversion is rikai dataset is incorrect but it was never tested. Triggered during working with bdd100K dataset as the annotations for object detection was an array of struct and had an inner struct for label properties (like occluded, trafficLightColor, etc).