### PR TITLE
DRAFT: Add the ability to write a pandas dataframe to disk in Rikai format without needing a live spark session

### DIFF
--- a/python/rikai/parquet/writer.py
+++ b/python/rikai/parquet/writer.py
@@ -1,0 +1,125 @@
+#  Copyright 2022 Rikai Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tools to write Rikai format datasets to disk
+"""
+
+import json
+import pyarrow as pa
+import pyarrow.parquet as pq
+from rikai.mixin import ToDict
+from rikai.parquet.dataset import Dataset as RikaiDataset
+import pandas as pd
+
+__all__ = ["df_to_rikai"]
+
+
+def df_to_rikai(
+    df: pd.DataFrame, dest_path: str, schema: "pyspark.sql.types.StructType"
+):
+    """Write the given pandas dataframe to the given location using the
+    specified (pyspark) schema
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        The DataFrame to write to Rikai format
+    dest_path: str
+        The destination path to write df to
+    schema: StructType
+        The pyspark schema required to convert Rikai types and make the
+        resulting rikai dataset readable by spark
+    """
+    schema_json_str = schema.json()
+    converted_df = conv(df, json.loads(schema_json_str))  # convert Rikai types
+    # The spark schema is required so Spark can read it successfully
+    table = pa.Table.from_pandas(converted_df).replace_schema_metadata(
+        {RikaiDataset.SPARK_PARQUET_ROW_METADATA: schema_json_str}
+    )
+    pq.write_to_dataset(table, dest_path, use_legacy_dataset=False)
+
+
+def conv(df: pd.DataFrame, schema: dict):
+    """Convert the given pandas dataframe to native types
+
+    Returns
+    -------
+    converted: pd.DataFrame
+        A dataframe where all Rikai types have been converted
+    """
+    assert schema["type"] == "struct"
+    converted = {}
+    for field in schema["fields"]:
+        name = field["name"]
+        ser = df[name]
+        typ = field["type"]
+        if not isinstance(typ, dict):
+            converted[name] = ser
+        elif is_udt_type(typ):
+            converted[name] = ser.apply(lambda x: _conv_udt(x, typ))
+        elif typ["type"] == "array":
+            converted[name] = ser.apply(
+                lambda arr: [conv_elm(x, typ["elementType"]) for x in arr]
+            )
+        elif typ["type"] == "struct":
+            converted[name] = ser.apply(lambda d: conv_elm(d, typ))
+        else:
+            converted[name] = ser
+    return pd.DataFrame(converted)
+
+
+def is_udt_type(typ: dict):
+    """Check whether a given field type information is a udt"""
+    if typ["type"] == "udt":
+        udt = RikaiDataset._find_udt(typ["pyClass"])
+        return udt is not None
+    return False
+
+
+def conv_elm(elm, schema):
+    """Convert a single value given it's schema information"""
+    if is_udt_type(schema):
+        return elm.to_dict()
+    elif schema["type"] == "array":
+        return [conv_elm(x, schema["elementType"]) for x in elm]
+    elif schema["type"] == "struct":
+        converted = {}
+        for field in schema["fields"]:
+            name = field["name"]
+            typ = field["type"]
+            if not isinstance(typ, dict):
+                converted[name] = elm[name]
+            elif is_udt_type(typ):
+                converted[name] = _conv_udt(elm[name], typ)
+            elif typ["type"] == "array":
+                converted[name] = [
+                    conv_elm(x, typ["elementType"]) for x in elm[name]
+                ]
+            elif typ["type"] == "struct":
+                converted[name] = conv_elm(elm[name], typ)
+            else:
+                converted[name] = elm[name]
+        return converted
+    else:
+        return elm
+
+
+def _conv_udt(v, typ):
+    """Convert the UDT value to a serializable format"""
+    if isinstance(v, ToDict):
+        return v.to_dict()
+    else:
+        assert typ["type"] == "udt"
+        udt = RikaiDataset._find_udt(typ["pyClass"])
+        return udt.serialize(v)

--- a/python/rikai/spark/sql/codegen/fs.py
+++ b/python/rikai/spark/sql/codegen/fs.py
@@ -14,7 +14,7 @@
 
 import os
 from pathlib import Path
-from typing import Dict, Any, Union
+from typing import Any, Dict, Union
 from urllib.parse import urlparse
 
 import yaml

--- a/python/rikai/spark/types/geometry.py
+++ b/python/rikai/spark/types/geometry.py
@@ -60,20 +60,20 @@ class Box2dType(UserDefinedType):
 
     def serialize(self, obj: "rikai.types.geometry.Box2d"):
         """Serialize a Box2d into a PySpark Row"""
-        return (
-            obj.xmin,
-            obj.ymin,
-            obj.xmax,
-            obj.ymax,
+        return Row(
+            xmin=obj.xmin,
+            ymin=obj.ymin,
+            xmax=obj.xmax,
+            ymax=obj.ymax,
         )
 
     def deserialize(self, datum: Row) -> "rikai.types.geometry.Box2d":
         from rikai.types.geometry import Box2d
 
-        if len(datum) < 4:
+        if len(datum) != 4:
             logger.error(f"Deserialize box2d: not sufficient data: {datum}")
 
-        return Box2d(*datum[:4])
+        return Box2d(**datum.asDict())
 
     def simpleString(self) -> str:
         return "box2d"

--- a/python/tests/parquet/test_writer.py
+++ b/python/tests/parquet/test_writer.py
@@ -1,0 +1,64 @@
+#  Copyright 2022 Rikai Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import json
+from pathlib import Path
+import pandas as pd
+from pyspark.sql import SparkSession
+from pyspark.sql.types import *
+
+from rikai.parquet.dataset import Dataset
+from rikai.spark.types import *
+from rikai.types import *
+from rikai.parquet.writer import df_to_rikai
+
+
+def test_roundtrip(spark: SparkSession, tmp_path: Path):
+    schema = StructType(
+        fields=[
+            StructField("image_id", StringType()),
+            StructField("image", ImageType()),
+            StructField(
+                "annotations",
+                ArrayType(
+                    elementType=StructType(
+                        fields=[
+                            StructField("label", StringType()),
+                            StructField("box", Box2dType()),
+                        ]
+                    )
+                ),
+            ),
+        ]
+    )
+    df = pd.DataFrame(
+        [
+            {
+                "image_id": "1",
+                "image": Image("s3://bucket/path.jpg"),
+                "annotations": [
+                    {
+                        "label": "car",
+                        "box": Box2d(xmin=0, ymin=0, xmax=100, ymax=100),
+                    }
+                ],
+            }
+        ]
+    )
+    df_to_rikai(df, str(tmp_path), schema)
+
+    pandas_df = pd.DataFrame(Dataset(str(tmp_path)))
+    assert isinstance(pandas_df.image[0], Image)
+    spark_df = spark.read.format("rikai").load(str(tmp_path))
+    assert schema.json() == spark_df.schema.json()

--- a/python/tests/parquet/test_writer.py
+++ b/python/tests/parquet/test_writer.py
@@ -12,23 +12,96 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import json
 from pathlib import Path
+import random
+
+import numpy as np
 import pandas as pd
+from pyarrow.lib import ArrowInvalid
 from pyspark.sql import SparkSession
 from pyspark.sql.types import *
+import pytest
 
 from rikai.parquet.dataset import Dataset
+from rikai.parquet.writer import df_to_rikai
 from rikai.spark.types import *
 from rikai.types import *
-from rikai.parquet.writer import df_to_rikai
 
 
 def test_roundtrip(spark: SparkSession, tmp_path: Path):
+    df, schema = _make_df()
+    df_to_rikai(df, str(tmp_path), schema)
+
+    pandas_df = pd.DataFrame(Dataset(str(tmp_path)))
+    assert isinstance(pandas_df.image[0], Image)
+    spark_df = spark.read.format("rikai").load(str(tmp_path))
+    assert schema.json() == spark_df.schema.json()
+
+
+def test_partition_cols(tmp_path: Path):
+    df, schema = _make_df(1000)
+    df_to_rikai(
+        df, str(tmp_path), schema, partition_cols="split", max_rows_per_file=10
+    )
+    _verify_file_size(Path(tmp_path), max_rows_per_file=10)
+    partition_info = [(k, df[k].unique()) for k in ["split"]]
+    _verify_partitioning(Path(tmp_path), partition_info)
+
+
+def test_mode(spark: SparkSession, tmp_path: Path):
+    df, schema = _make_df(1000)
+    df_to_rikai(
+        df[df.split == "train"],
+        str(tmp_path),
+        schema,
+        partition_cols="split",
+        max_rows_per_file=10,
+    )
+    df1 = pd.DataFrame(Dataset(str(tmp_path)))
+    assert len(df1) == len(df[df.split == "train"])
+
+    # default is 'error'
+    with pytest.raises(ArrowInvalid):
+        df_to_rikai(
+            df,
+            str(tmp_path),
+            schema,
+            partition_cols="split",
+            max_rows_per_file=10,
+        )
+
+    # overwrite_or_ignore
+    df_to_rikai(
+        df,
+        str(tmp_path),
+        schema,
+        partition_cols="split",
+        max_rows_per_file=10,
+        mode="overwrite_or_ignore",
+    )
+    df2 = pd.DataFrame(Dataset(str(tmp_path)))
+    assert len(df2) == len(df)
+
+    # delete_matching should replace
+    df["image_id"] = df.image_id.apply(lambda x: str(-int(x)))
+    df_to_rikai(
+        df,
+        str(tmp_path),
+        schema,
+        partition_cols="split",
+        max_rows_per_file=10,
+        mode="delete_matching",
+    )
+    pdf = pd.DataFrame(Dataset(str(tmp_path)))
+    assert pdf.image_id.apply(int).apply(lambda x: x <= 0).all()
+
+
+def _make_df(nrows=1):
     schema = StructType(
         fields=[
             StructField("image_id", StringType()),
             StructField("image", ImageType()),
+            StructField("split", StringType()),
             StructField(
                 "annotations",
                 ArrayType(
@@ -42,23 +115,44 @@ def test_roundtrip(spark: SparkSession, tmp_path: Path):
             ),
         ]
     )
+
+    labels = ["car", "truck", "person", "traffic light"]
+    splits = ["train", "val", "test"]
     df = pd.DataFrame(
         [
             {
-                "image_id": "1",
-                "image": Image("s3://bucket/path.jpg"),
+                "image_id": str(i),
+                "image": Image(f"s3://bucket/path_{i}.jpg"),
+                "split": splits[random.randint(0, len(splits) - 1)],
                 "annotations": [
                     {
-                        "label": "car",
-                        "box": Box2d(xmin=0, ymin=0, xmax=100, ymax=100),
+                        "label": labels[random.randint(0, len(labels) - 1)],
+                        "box": Box2d(
+                            xmin=0,
+                            ymin=0,
+                            xmax=random.random() * 100 + 1,
+                            ymax=random.random() * 100 + 1,
+                        ),
                     }
                 ],
             }
+            for i in np.arange(nrows)
         ]
     )
-    df_to_rikai(df, str(tmp_path), schema)
+    return df, schema
 
-    pandas_df = pd.DataFrame(Dataset(str(tmp_path)))
-    assert isinstance(pandas_df.image[0], Image)
-    spark_df = spark.read.format("rikai").load(str(tmp_path))
-    assert schema.json() == spark_df.schema.json()
+
+def _verify_file_size(dest: Path, max_rows_per_file: int):
+    parquet_files = list(dest.glob("*.parquet"))
+    for filepath in parquet_files:
+        m = pq.ParquetFile(filepath).metadata
+        assert m.num_rows <= max_rows_per_file
+
+
+def _verify_partitioning(dest: Path, partition_info: list):
+    for part_dir in dest.iterdir():
+        col, value = part_dir.name.split("=")
+        assert col == partition_info[0][0]
+        assert value in partition_info[0][1]
+        if len(partition_info) > 1:
+            _verify_partitioning(part_dir, partition_info[1:])


### PR DESCRIPTION
Open issues:
1. I had to change how Box2d is serialized/deserialized to make it work (otherwise the elements are written out of order)
2. This probably means that other shapes are like also wrong right now, but I wanted to solicit feedback before testing/changing those
3. Right now you still need to give it an explicit StructType schema so the resulting dataset is readable by spark and it knows when to convert the Rikai types into native types. It would be nice to add an option to just infer the types based on a sample of rows in the DataFrame.
