### PR TITLE
[no ci] Separate RegistryTest out

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,6 +137,8 @@ scalacOptions ++= {
 
 Test / parallelExecution := false
 Test / fork := true
+
+// https://www.scala-sbt.org/1.x/docs/Testing.html#Forking+tests
 import Tests._
 {
   def groupByFirst(tests: Seq[TestDefinition]) =

--- a/build.sbt
+++ b/build.sbt
@@ -137,6 +137,22 @@ scalacOptions ++= {
 
 Test / parallelExecution := false
 Test / fork := true
+import Tests._
+{
+  def groupByFirst(tests: Seq[TestDefinition]) =
+    tests groupBy (_.name) map {
+      case (name, tests) =>
+        val options = ForkOptions()
+        // RegistryTest changes the mutable field of the Registry singleton
+        // Let us put it in the `group_0` JVM instance
+        if (name.endsWith("RegistryTest"))
+          new Group("group_0", tests, SubProcess(options))
+        else
+          new Group("group_1", tests, SubProcess(options))
+    } toSeq
+
+  Test / testGrouping := groupByFirst( (Test / definedTests).value )
+}
 
 Antlr4 / antlr4PackageName := Some("ai.eto.rikai.sql.spark.parser")
 Antlr4 / antlr4GenVisitor := true


### PR DESCRIPTION
#648 is meant to deliver the UDF `image` without having to register `to_image` in Python.

This pull request is part of #648 but does not belong to #648 .

On the main branch, we could use `make test` to reproduce https://github.com/eto-ai/rikai/runs/6300123281?check_suite_focus=true 

It happens occasionally.