### PR TITLE
Revert ""Bump version for python package: 0.1.11.dev0 -> 0.1.11""

### DIFF
--- a/python/.bumpversion.cfg
+++ b/python/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = 0.1.11
+current_version = 0.1.11.dev0
 parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?(\.(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{release}{build}

--- a/python/rikai/__version__.py
+++ b/python/rikai/__version__.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-version = "0.1.11"
+version = "0.1.11.dev0"


### PR DESCRIPTION
This reverts commit 946dcb4ab69c445464c8bb5b97abf00a8e98194d.