### PR TITLE
Use the same Python interpreter for drive and executor

### DIFF
--- a/python/rikai/spark/utils.py
+++ b/python/rikai/spark/utils.py
@@ -53,8 +53,8 @@ def init_spark_session(
     import os
     import sys
 
-    os.environ['PYSPARK_PYTHON'] = sys.executable
-    os.environ['PYSPARK_DRIVER_PYTHON'] = sys.executable
+    os.environ["PYSPARK_PYTHON"] = sys.executable
+    os.environ["PYSPARK_DRIVER_PYTHON"] = sys.executable
 
     # Avoid reused session polluting configs
     active_session = SparkSession.getActiveSession()

--- a/python/rikai/spark/utils.py
+++ b/python/rikai/spark/utils.py
@@ -50,6 +50,11 @@ def init_spark_session(
     conf: dict = None, app_name="rikai", rikai_version=None, num_cores=2
 ):
     from pyspark.sql import SparkSession
+    import os
+    import sys
+
+    os.environ['PYSPARK_PYTHON'] = sys.executable
+    os.environ['PYSPARK_DRIVER_PYTHON'] = sys.executable
 
     # Avoid reused session polluting configs
     active_session = SparkSession.getActiveSession()


### PR DESCRIPTION
```
/path/to/python rikai_xxx.py
```
when we didn't activate the python virtual environment, the python interpreter for executor will use the default python interpreter.