### PR TITLE
Support for Spark 3.3.1

### DIFF
--- a/.github/workflows/python_3_8.yml
+++ b/.github/workflows/python_3_8.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8]
         spark-version: [3.2.1]
     timeout-minutes: 30
     steps:
@@ -65,22 +65,3 @@ jobs:
       env:
         SPARK_LOCAL_IP: "127.0.0.1"
         TEST_MLFLOW_TRACKING_URI: "http://localhost:15000"
-  mac-build:
-    runs-on: macos-12
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup Scala
-      uses: olafurpg/setup-scala@v10
-      with:
-        java-version: adopt@1.11
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Test Pip install
-      working-directory: python
-      run: |
-        python -m pip install -q wheel
-        python setup.py bdist_wheel
-        python -m pip install $(ls dist/rikai*.whl)

--- a/.github/workflows/python_3_8.yml
+++ b/.github/workflows/python_3_8.yml
@@ -1,4 +1,4 @@
-name: Python
+name: Python 3.8
 
 on:
   push:

--- a/.github/workflows/python_3_9.yml
+++ b/.github/workflows/python_3_9.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9]
-        spark-version: [3.3.0]
+        spark-version: [3.3.1]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python_3_9.yml
+++ b/.github/workflows/python_3_9.yml
@@ -1,4 +1,4 @@
-name: Python
+name: Python 3.9
 
 on:
   push:

--- a/.github/workflows/python_3_9.yml
+++ b/.github/workflows/python_3_9.yml
@@ -1,0 +1,86 @@
+name: Python
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.9]
+        spark-version: [3.3.0]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'python/setup.py'
+      - name: cache SBT
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+      - name: cache official pretrained Torch models
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/torch/hub/checkpoints
+          key: ${{ runner.os }}-pt-${{ hashFiles('**/setup.py') }}
+      - name: sbt install
+        run: |
+          echo "SPARK_VERSION=${{matrix.spark-version}}" >> $GITHUB_ENV
+          export SPARK_VERSION=${{matrix.spark-version}}
+          sbt publishLocal
+      - name: Start docker-compose
+        run: |
+          docker-compose -f .github/docker-compose.yml up -d
+      - name: apt update and install
+        run: |
+          sudo apt update
+          sudo apt-get -y -qq install libsnappy-dev ffmpeg
+      - name: Pip install
+        working-directory: python
+        run: |
+          python -m pip install -e .[all,dev]
+      - name: Run python tests
+        working-directory: python
+        run: |
+          pytest -x -v --durations=10 --ignore=tests/parquet/internal
+        env:
+          SPARK_LOCAL_IP: "127.0.0.1"
+          TEST_MLFLOW_TRACKING_URI: "http://localhost:15000"
+  mac-build:
+    runs-on: macos-12
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Test Pip install
+        working-directory: python
+        run: |
+          python -m pip install -q wheel
+          python setup.py bdist_wheel
+          python -m pip install $(ls dist/rikai*.whl)

--- a/.github/workflows/scala_2_12.yml
+++ b/.github/workflows/scala_2_12.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         scala-version: [2.12.16]
         java-version: ['8', '11']
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/scala_2_12.yml
+++ b/.github/workflows/scala_2_12.yml
@@ -1,4 +1,4 @@
-name: Scala
+name: Scala 2.12.x
 
 on:
   push:

--- a/.github/workflows/scala_2_12.yml
+++ b/.github/workflows/scala_2_12.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        scala-version: 2.12.16
+        scala-version: [2.12.16]
         java-version: ['8', '11']
     timeout-minutes: 15
     steps:

--- a/.github/workflows/scala_2_12.yml
+++ b/.github/workflows/scala_2_12.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        scala-version: [ 2.12.16, 2.13.8 ]
+        scala-version: 2.12.16
         java-version: ['8', '11']
     timeout-minutes: 15
     steps:

--- a/.github/workflows/scala_2_13.yml
+++ b/.github/workflows/scala_2_13.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         scala-version: [2.13.8]
         java-version: ['8', '11']
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/scala_2_13.yml
+++ b/.github/workflows/scala_2_13.yml
@@ -1,0 +1,48 @@
+name: Scala
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        scala-version: 2.13.8
+        java-version: ['8', '11']
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Start docker-compose
+        run: |
+          docker-compose -f .github/docker-compose.yml up -d
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Pip install
+        working-directory: python
+        run: |
+          python -m pip install -e .[pytorch,mlflow]
+      - name: Run Scala tests
+        run: sbt ++${{matrix.scala-version}} test
+        env:
+          SPARK_VERSION: "3.3.0"
+          SPARK_LOCAL_IP: "127.0.0.1"
+          TEST_MLFLOW_TRACKING_URI: "http://localhost:15000"
+      - name: Build Scala Jar
+        run: sbt package
+        env:
+          SPARK_VERSION: "3.3.0"
+      - name: Stop docker-compose
+        run: docker-compose -f .github/docker-compose.yml down

--- a/.github/workflows/scala_2_13.yml
+++ b/.github/workflows/scala_2_13.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        scala-version: 2.13.8
+        scala-version: [2.13.8]
         java-version: ['8', '11']
     timeout-minutes: 15
     steps:

--- a/.github/workflows/scala_2_13.yml
+++ b/.github/workflows/scala_2_13.yml
@@ -1,4 +1,4 @@
-name: Scala
+name: Scala 2.13.x
 
 on:
   push:

--- a/.github/workflows/scala_2_13.yml
+++ b/.github/workflows/scala_2_13.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Run Scala tests
         run: sbt ++${{matrix.scala-version}} test
         env:
-          SPARK_VERSION: "3.3.0"
+          SPARK_VERSION: "3.3.1"
           SPARK_LOCAL_IP: "127.0.0.1"
           TEST_MLFLOW_TRACKING_URI: "http://localhost:15000"
       - name: Build Scala Jar
         run: sbt package
         env:
-          SPARK_VERSION: "3.3.0"
+          SPARK_VERSION: "3.3.1"
       - name: Stop docker-compose
         run: docker-compose -f .github/docker-compose.yml down

--- a/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtSparkSQLParser.scala
+++ b/src/main/scala/ai/eto/rikai/sql/spark/parser/RikaiExtSparkSQLParser.scala
@@ -17,6 +17,8 @@
 package ai.eto.rikai.sql.spark.parser
 
 import ai.eto.rikai.sql.model.Registry
+import com.thoughtworks.enableIf
+import com.thoughtworks.enableIf.classpathMatches
 import org.antlr.v4.runtime._
 import org.antlr.v4.runtime.atn.PredictionMode
 import org.antlr.v4.runtime.misc.{Interval, ParseCancellationException}
@@ -138,6 +140,9 @@ private[spark] class RikaiExtSqlParser(
   override def parseDataType(sqlText: String): DataType =
     delegate.parseDataType(sqlText)
 
+  @enableIf(classpathMatches(".*spark-catalyst_2\\.\\d+-3\\.[^012]\\..*".r))
+  override def parseQuery(sqlText: String): LogicalPlan =
+    delegate.parseQuery(sqlText)
 }
 
 private[spark] object RikaiExtSqlParser {


### PR DESCRIPTION
+ Python 3.9 Spark 3.2.1 -> Python 3.9 Spark 3.3.0
+ Scala 2.13 Java 8 Spark 3.2.0 -> Scala 2.13 Java 8 Spark 3.3.0
+ Scala 2.13 Java 11 Spark 3.2.0 -> Scala 2.13 Java 8 Spark 3.3.0

> Why Spark 3.3.0 should be tested with Python 3.9?

Databricks 11.3 LTS is using Spark 3.3.0 and Python 3.9
