### PR TITLE
Support dot separated flavor

### DIFF
--- a/python/rikai/spark/sql/codegen/base.py
+++ b/python/rikai/spark/sql/codegen/base.py
@@ -73,10 +73,10 @@ def codegen_from_spec(spec: ModelSpec):
     ModuleType
         The imported module for the specific flavor codegen
     """
-    if spec.flavor in KNOWN_FLAVORS:
-        codegen_module = f"rikai.spark.sql.codegen.{spec.flavor}"
-    elif is_fully_qualified_name(spec.flavor):
+    if is_fully_qualified_name(spec.flavor):
         codegen_module = f"{spec.flavor}.codegen"
+    elif spec.flavor in KNOWN_FLAVORS:
+        codegen_module = f"rikai.spark.sql.codegen.{spec.flavor}"
     else:
         codegen_module = f"rikai.contrib.{spec.flavor}.codegen"
 

--- a/python/rikai/spark/sql/codegen/mlflow_registry.py
+++ b/python/rikai/spark/sql/codegen/mlflow_registry.py
@@ -39,6 +39,7 @@ from rikai.spark.sql.codegen.mlflow_logger import (
     MlflowLogger,
 )
 from rikai.spark.sql.exceptions import SpecError
+from rikai.spark.sql.model import is_fully_qualified_name
 
 __all__ = ["MlflowRegistry"]
 
@@ -86,6 +87,10 @@ class MlflowModelSpec(ModelSpec):
                 return mlflow.pyfunc.load_model(
                     self.model_uri
                 )._model_impl.model
+            elif is_fully_qualified_name(self.flavor):
+                return getattr(mlflow, self.flavor.split(".")[-1]).load_model(
+                    self.model_uri
+                )
             else:
                 return getattr(mlflow, self.flavor).load_model(self.model_uri)
         finally:

--- a/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
+++ b/src/main/antlr4/org/apache/spark/sql/ml/parser/RikaiExtSqlBase.g4
@@ -21,7 +21,7 @@ singleStatement
 
 statement
     : CREATE (OR REPLACE)? MODEL (IF NOT EXISTS)? model=qualifiedName
-      (FLAVOR flavor=identifier)?
+      (FLAVOR flavor=qualifiedName)?
       (MODEL_TYPE modeltype=qualifiedName)?
       (OPTIONS optionList)?
       (RETURNS datatype=dataType)?


### PR DESCRIPTION
Currently, `customized_flavor` could only be placed under `rikai.contrib.{customized_flavor}`.

With this pull request, we can use `xyz.sklearn` and put `codegen.py` into the folder `xyz/sklearn`.

TODO
+ [ ] Unit tests for Antlr changes
+ [ ] Unit tests for the python part
+ [ ] Documentation on flavor
+ [ ] Display flavor in `show models`